### PR TITLE
MATH-1269

### DIFF
--- a/src/main/java/org/apache/commons/math4/util/FastMath.java
+++ b/src/main/java/org/apache/commons/math4/util/FastMath.java
@@ -915,7 +915,11 @@ public class FastMath {
             intVal--;
 
         } else {
-            if (intVal > 709) {
+            // exp(709.7827128934) already overflows Double.MAX_VALUE and becomes infinite.
+            // Values between 709.7827128934 and 710.0 can cause problems.
+            // So it's better to avoid dealing with them.
+            // See https://issues.apache.org/jira/browse/MATH-1269
+            if (intVal > 709 || intVal == 709 && x >= 709.7827128934) {
                 if (hiPrec != null) {
                     hiPrec[0] = Double.POSITIVE_INFINITY;
                     hiPrec[1] = 0.0;

--- a/src/test/java/org/apache/commons/math4/util/FastMathTest.java
+++ b/src/test/java/org/apache/commons/math4/util/FastMathTest.java
@@ -541,6 +541,31 @@ public class FastMathTest {
 
         Assert.assertTrue("pow() had errors in excess of " + MAX_ERROR_ULP + " ULP", maxerrulp < MAX_ERROR_ULP);
     }
+    
+    @Test
+    public void testExpHighBorder() {
+        final double EXACT = -1.0;
+        Assert.assertEquals(Double.NaN, FastMath.exp(Double.NaN), EXACT);
+        Assert.assertTrue(FastMath.exp(709.0) < Double.MAX_VALUE);
+        Assert.assertTrue(FastMath.exp(709.7) < Double.MAX_VALUE);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.8), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.81), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.812), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.8124), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.81245), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.8125), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.81255), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.8126), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.813), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.82), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(709.9), EXACT);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, FastMath.exp(710.0), EXACT);
+        // Values near log( Double.MAX_VALUE ) = 709.7827128933839967276924307167.
+        for (long l = Double.doubleToRawLongBits(709.7827128933); l <= Double.doubleToRawLongBits(709.78271289341); l++) {
+            double d = Double.longBitsToDouble(l);
+            Assert.assertFalse(Double.isNaN(FastMath.exp(d)));
+        }
+    }
 
     @Test
     public void testExpAccuracy() {


### PR DESCRIPTION
Fix: FastMath.exp(709.8125) returns NaN but should return positive infinity.