### PR TITLE
MATH-1272

### DIFF
--- a/src/main/java/org/apache/commons/math4/util/FastMath.java
+++ b/src/main/java/org/apache/commons/math4/util/FastMath.java
@@ -1711,7 +1711,7 @@ public class FastMath {
         }
 
         /** Computes this^e.
-         * @param e exponent (beware, here it MUST be > 0)
+         * @param e exponent (beware, here it MUST be > 0; the only exclusion is Long.MIN_VALUE)
          * @return d^e, split in high and low bits
          * @since 4.0
          */
@@ -1723,7 +1723,7 @@ public class FastMath {
             // d^(2p)
             Split d2p = new Split(full, high, low);
 
-            for (long p = e; p != 0; p >>= 1) {
+            for (long p = e; p != 0; p >>>= 1) {
 
                 if ((p & 0x1) != 0) {
                     // accurate multiplication result = result * d^(2p) using Veltkamp TwoProduct algorithm

--- a/src/test/java/org/apache/commons/math4/util/FastMathTest.java
+++ b/src/test/java/org/apache/commons/math4/util/FastMathTest.java
@@ -1232,6 +1232,11 @@ public class FastMathTest {
         Assert.assertTrue(Double.isInfinite(FastMath.pow(FastMath.scalb(1.0, 500), 4)));
     }
 
+    @Test(timeout=5000L) // This test must finish in finite time.
+    public void testIntPowLongMinValue() {
+        Assert.assertEquals(1.0, FastMath.pow(1.0, Long.MIN_VALUE), -1.0);
+    }
+
     @Test
     public void testIncrementExactInt() {
         int[] specialValues = new int[] {


### PR DESCRIPTION
FastMath.pow(double, long) enters an infinite loop with Long.MIN_VALUE. It cannot be negated, so unsigned shift (>>>) is required instead of a signed one.