### PR TITLE
Math1302and1303

### DIFF
--- a/src/main/java/org/apache/commons/math4/geometry/euclidean/threed/Rotation.java
+++ b/src/main/java/org/apache/commons/math4/geometry/euclidean/threed/Rotation.java
@@ -564,9 +564,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(true);
       }
       return new double[] {
-        FastMath.atan2(-(v1.getY()), v1.getZ()),
+        FastMath.atan2(-(v2.getY()), v2.getX()),
         FastMath.asin(v2.getZ()),
-        FastMath.atan2(-(v2.getY()), v2.getX())
+        FastMath.atan2(-(v1.getY()), v1.getZ())
       };
 
     } else if (order == RotationOrder.YZX) {
@@ -582,9 +582,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(true);
       }
       return new double[] {
-        FastMath.atan2(v1.getZ(), v1.getY()),
+        FastMath.atan2(v2.getZ(), v2.getX()),
        -FastMath.asin(v2.getY()),
-        FastMath.atan2(v2.getZ(), v2.getX())
+        FastMath.atan2(v1.getZ(), v1.getY())
       };
 
     } else if (order == RotationOrder.ZXY) {
@@ -600,9 +600,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(true);
       }
       return new double[] {
-        FastMath.atan2(v1.getX(), v1.getZ()),
+        FastMath.atan2(v2.getX(), v2.getY()),
        -FastMath.asin(v2.getZ()),
-        FastMath.atan2(v2.getX(), v2.getY())
+        FastMath.atan2(v1.getX(), v1.getZ())
       };
 
     } else if (order == RotationOrder.XZY) {
@@ -618,9 +618,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(true);
       }
       return new double[] {
-        FastMath.atan2(-(v1.getZ()), v1.getX()),
+        FastMath.atan2(-(v2.getZ()), v2.getY()),
         FastMath.asin(v2.getX()),
-        FastMath.atan2(-(v2.getZ()), v2.getY())
+        FastMath.atan2(-(v1.getZ()), v1.getX())
       };
 
     } else if (order == RotationOrder.YXZ) {
@@ -636,9 +636,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(true);
       }
       return new double[] {
-        FastMath.atan2(-(v1.getX()), v1.getY()),
+        FastMath.atan2(-(v2.getX()), v2.getZ()),
         FastMath.asin(v2.getY()),
-        FastMath.atan2(-(v2.getX()), v2.getZ())
+        FastMath.atan2(-(v1.getX()), v1.getY())
       };
 
     } else if (order == RotationOrder.XYZ) {
@@ -654,9 +654,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(true);
       }
       return new double[] {
-        FastMath.atan2(v1.getY(), v1.getX()),
+        FastMath.atan2(v2.getY(), v2.getZ()),
        -FastMath.asin(v2.getX()),
-        FastMath.atan2(v2.getY(), v2.getZ())
+        FastMath.atan2(v1.getY(), v1.getX())
       };
 
     } else if (order == RotationOrder.XYX) {
@@ -672,9 +672,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(false);
       }
       return new double[] {
-        FastMath.atan2(v1.getY(), -v1.getZ()),
+        FastMath.atan2(v2.getY(), v2.getZ()),
         FastMath.acos(v2.getX()),
-        FastMath.atan2(v2.getY(), v2.getZ())
+        FastMath.atan2(v1.getY(), -v1.getZ())
       };
 
     } else if (order == RotationOrder.XZX) {
@@ -690,9 +690,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(false);
       }
       return new double[] {
-        FastMath.atan2(v1.getZ(), v1.getY()),
+        FastMath.atan2(v2.getZ(), -v2.getY()),
         FastMath.acos(v2.getX()),
-        FastMath.atan2(v2.getZ(), -v2.getY())
+        FastMath.atan2(v1.getZ(), v1.getY())
       };
 
     } else if (order == RotationOrder.YXY) {
@@ -708,9 +708,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(false);
       }
       return new double[] {
-        FastMath.atan2(v1.getX(), v1.getZ()),
+        FastMath.atan2(v2.getX(), -v2.getZ()),
         FastMath.acos(v2.getY()),
-        FastMath.atan2(v2.getX(), -v2.getZ())
+        FastMath.atan2(v1.getX(), v1.getZ())
       };
 
     } else if (order == RotationOrder.YZY) {
@@ -726,9 +726,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(false);
       }
       return new double[] {
-        FastMath.atan2(v1.getZ(), -v1.getX()),
+        FastMath.atan2(v2.getZ(), v2.getX()),
         FastMath.acos(v2.getY()),
-        FastMath.atan2(v2.getZ(), v2.getX())
+        FastMath.atan2(v1.getZ(), -v1.getX())
       };
 
     } else if (order == RotationOrder.ZXZ) {
@@ -744,9 +744,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(false);
       }
       return new double[] {
-        FastMath.atan2(v1.getX(), -v1.getY()),
+        FastMath.atan2(v2.getX(), v2.getY()),
         FastMath.acos(v2.getZ()),
-        FastMath.atan2(v2.getX(), v2.getY())
+        FastMath.atan2(v1.getX(), -v1.getY())
       };
 
     } else { // last possibility is ZYZ
@@ -762,9 +762,9 @@ public class Rotation implements Serializable {
         throw new CardanEulerSingularityException(false);
       }
       return new double[] {
-        FastMath.atan2(v1.getY(), v1.getX()),
+        FastMath.atan2(v2.getY(), -v2.getX()),
         FastMath.acos(v2.getZ()),
-        FastMath.atan2(v2.getY(), -v2.getX())
+        FastMath.atan2(v1.getY(), v1.getX())
       };
 
     }

--- a/src/main/java/org/apache/commons/math4/geometry/euclidean/threed/Rotation.java
+++ b/src/main/java/org/apache/commons/math4/geometry/euclidean/threed/Rotation.java
@@ -551,7 +551,7 @@ public class Rotation implements Serializable {
   public double[] getAngles(RotationOrder order)
     throws CardanEulerSingularityException {
 
-    if (order == RotationOrder.XYZ) {
+    if (order == RotationOrder.ZYX) {
 
       // r (Vector3D.plusK) coordinates are :
       //  sin (theta), -cos (theta) sin (phi), cos (theta) cos (phi)
@@ -569,7 +569,7 @@ public class Rotation implements Serializable {
         FastMath.atan2(-(v2.getY()), v2.getX())
       };
 
-    } else if (order == RotationOrder.XZY) {
+    } else if (order == RotationOrder.YZX) {
 
       // r (Vector3D.plusJ) coordinates are :
       // -sin (psi), cos (psi) cos (phi), cos (psi) sin (phi)
@@ -587,7 +587,7 @@ public class Rotation implements Serializable {
         FastMath.atan2(v2.getZ(), v2.getX())
       };
 
-    } else if (order == RotationOrder.YXZ) {
+    } else if (order == RotationOrder.ZXY) {
 
       // r (Vector3D.plusK) coordinates are :
       //  cos (phi) sin (theta), -sin (phi), cos (phi) cos (theta)
@@ -605,7 +605,7 @@ public class Rotation implements Serializable {
         FastMath.atan2(v2.getX(), v2.getY())
       };
 
-    } else if (order == RotationOrder.YZX) {
+    } else if (order == RotationOrder.XZY) {
 
       // r (Vector3D.plusI) coordinates are :
       // cos (psi) cos (theta), sin (psi), -cos (psi) sin (theta)
@@ -623,7 +623,7 @@ public class Rotation implements Serializable {
         FastMath.atan2(-(v2.getZ()), v2.getY())
       };
 
-    } else if (order == RotationOrder.ZXY) {
+    } else if (order == RotationOrder.YXZ) {
 
       // r (Vector3D.plusJ) coordinates are :
       // -cos (phi) sin (psi), cos (phi) cos (psi), sin (phi)
@@ -641,7 +641,7 @@ public class Rotation implements Serializable {
         FastMath.atan2(-(v2.getX()), v2.getZ())
       };
 
-    } else if (order == RotationOrder.ZYX) {
+    } else if (order == RotationOrder.XYZ) {
 
       // r (Vector3D.plusI) coordinates are :
       //  cos (theta) cos (psi), cos (theta) sin (psi), -sin (theta)

--- a/src/main/java/org/apache/commons/math4/geometry/euclidean/threed/Rotation.java
+++ b/src/main/java/org/apache/commons/math4/geometry/euclidean/threed/Rotation.java
@@ -18,7 +18,6 @@
 package org.apache.commons.math4.geometry.euclidean.threed;
 
 import java.io.Serializable;
-
 import org.apache.commons.math4.exception.MathArithmeticException;
 import org.apache.commons.math4.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.exception.util.LocalizedFormats;
@@ -378,7 +377,7 @@ public class Rotation implements Serializable {
       Rotation r1 = new Rotation(order.getA1(), alpha1);
       Rotation r2 = new Rotation(order.getA2(), alpha2);
       Rotation r3 = new Rotation(order.getA3(), alpha3);
-      Rotation composed = r1.applyTo(r2.applyTo(r3));
+      Rotation composed = r3.applyTo(r2.applyTo(r1));
       q0 = composed.q0;
       q1 = composed.q1;
       q2 = composed.q2;

--- a/src/test/java/org/apache/commons/math4/geometry/euclidean/threed/RotationTest.java
+++ b/src/test/java/org/apache/commons/math4/geometry/euclidean/threed/RotationTest.java
@@ -31,6 +31,24 @@ import org.junit.Test;
 
 
 public class RotationTest {
+	
+  @Test
+  public void testFromOrderAndAngles() {
+    final double xRotation = 30.0;
+    final double yRotation = 20.0;
+    final double zRotation = 10.0;
+    Vector3D expectedVector = Vector3D.PLUS_I;
+    expectedVector = new Rotation(RotationOrder.ZYX, zRotation, 0, 0).applyTo(expectedVector);
+    expectedVector = new Rotation(RotationOrder.ZYX, 0, yRotation, 0).applyTo(expectedVector);
+    expectedVector = new Rotation(RotationOrder.ZYX, 0, 0, xRotation).applyTo(expectedVector);
+
+    final Vector3D resultVector = new Rotation(RotationOrder.ZYX, zRotation, yRotation, xRotation)
+      .applyTo(Vector3D.PLUS_I);
+
+    Assert.assertEquals(resultVector.getX(), expectedVector.getX(), 1e-12);
+    Assert.assertEquals(resultVector.getY(), expectedVector.getY(), 1e-12);
+    Assert.assertEquals(resultVector.getZ(), expectedVector.getZ(), 1e-12);
+  }
 
   @Test
   public void testIdentity() {


### PR DESCRIPTION
Commit changes and comments below were done with the assistance of @drbassett.

When using one of the `Rotation` constructors, we noticed our rotations were not producing the correct results. This commit fixes the `Rotation` constructor.

Additionally, we noticed the tests around `getAngles` inside `Rotation` are dependent upon this constructor and the implementation of `getAngles` was unfortunately incorrect as well, but went unnoticed because the tests were passing. This commit also corrects the `getAngles` method.

See test code below explaining our changes:

```java
package rotation;

import org.apache.commons.math3.geometry.euclidean.threed.Rotation;
import org.apache.commons.math3.geometry.euclidean.threed.RotationOrder;
import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
import static org.junit.Assert.assertEquals;
import org.junit.Test;

public class RotationTesting
{
  private final RotationOrder order = RotationOrder.ZYX;
  private final double xRotation = 30;
  private final double yRotation = 20;
  private final double zRotation = 10;
  private final Vector3D startingVector = Vector3D.PLUS_I;

  @Test
  public void testShowingFailure()
  {
    // Here are our good values:
    final Vector3D appliedIndividually = getGoodVector();

    // Here is what we get from the Rotation constructor:
    final Vector3D bad = new Rotation(order, zRotation, yRotation, xRotation).applyTo(startingVector);

    // This should pass, but it doesn't:
    assertEquals(bad.getX(), appliedIndividually.getX(), 1e-12);
    assertEquals(bad.getY(), appliedIndividually.getY(), 1e-12);
    assertEquals(bad.getZ(), appliedIndividually.getZ(), 1e-12);
  }

  @Test
  public void testShowingFix()
  {
    // Here are our good values:
    final Vector3D appliedIndividually = getGoodVector();

    // Here is the fix for what should be in the Rotation constructor:
    final Rotation r1 = new Rotation(order.getA1(), zRotation);
    final Rotation r2 = new Rotation(order.getA2(), xRotation);
    final Rotation r3 = new Rotation(order.getA3(), yRotation);
    final Rotation composite = r3.applyTo(r2.applyTo(r1));
	// Swapping r3 and r1 adhears to the documentation of applyTo and 
	// produces the correct composite rotation. 
	
	// Additionally, all the Cardan rotation orders found in Rotation's
	// getAngles method need to be reversed or all the tests for getAngles
	// will break when the constructor is corrected. This is because the tests
	// use the incorrect implementation of the constructor for their values (which
	// resulted in an incorrect implementation of getAngles). This work has 
	// already been done within the commit.

    // So when we apply it to a vector...
    final Vector3D good = composite.applyTo(startingVector);

    // This does pass:
    assertEquals(good.getX(), appliedIndividually.getX(), 1e-12);
    assertEquals(good.getY(), appliedIndividually.getY(), 1e-12);
    assertEquals(good.getZ(), appliedIndividually.getZ(), 1e-12);
  }

  private Vector3D getGoodVector()
  {
    Vector3D appliedIndividually = startingVector;
    appliedIndividually = new Rotation(order, zRotation, 0, 0).applyTo(appliedIndividually);
    appliedIndividually = new Rotation(order, 0, yRotation, 0).applyTo(appliedIndividually);
    appliedIndividually = new Rotation(order, 0, 0, xRotation).applyTo(appliedIndividually);
    return appliedIndividually;
  }
}
```