### PR TITLE
Removing test redundant for org.apache.commons.math4.special.GammaTest.testLogGammaNegative

### DIFF
--- a/src/test/java/org/apache/commons/math4/special/GammaTest.java
+++ b/src/test/java/org/apache/commons/math4/special/GammaTest.java
@@ -339,7 +339,7 @@ public class GammaTest {
         Assert.assertTrue(Double.isNaN(Gamma.logGamma(0.0)));
     }
 
-    @Test
+    @Test @org.junit.Ignore
     public void testLogGammaPrecondition2() {
         Assert.assertTrue(Double.isNaN(Gamma.logGamma(-1.0)));
     }


### PR DESCRIPTION
We are researchers working on identifying redundant tests in a test suite. Our analysis of finding redundant tests involve each test's dynamic code coverage and their potential fault-detection capability.

Through our analysis, we found that the tests org.apache.commons.math4.special.GammaTest.testLogGammaNegative, org.apache.commons.math4.special.GammaTest.testLogGammaPrecondition2 are redundant with respect to one another. In this pull request, we are proposing to keep only the test org.apache.commons.math4.special.GammaTest.testLogGammaNegative while adding @Ignore annotations to the remaining test. However, as we believe these tests are identical, any one of them can be kept while skipping the remaining test.

If you do not believe any of these tests should be ignored, we would greatly appreciate it if you could follow up on this pull request and let us know your reasons.