### PR TITLE
[MATH-1390] LUDecomposition slow on larger matrices

### DIFF
--- a/src/test/java/org/apache/commons/math4/linear/LUDecompositionTest.java
+++ b/src/test/java/org/apache/commons/math4/linear/LUDecompositionTest.java
@@ -325,7 +325,6 @@ public class LUDecompositionTest {
     	RealMatrix u = lu.getU();
     	RealMatrix p = lu.getP();
     	double norm = l.multiply(u).subtract(p.multiply(A)).getNorm();
-    	System.out.println("testLargeRandomMatrix, norm = " + norm);
     	Assert.assertEquals(0, norm, 1e-11);	// norm = 9.559464331232448E-12
     }
 


### PR DESCRIPTION
Minimal changes to revert 'LUDecomposition' to the (original) faster JAMA implementation + some stylistic changes. Performance gain is ca. 10x for matrices of size 1500 x 1500. Added two new JUnit tests in 'LUDecompositionTest' to check large matrices and the Solver class.
TODO: 'FieldLUDecomposition' should be revised analogously.