### PR TITLE
MATH-1397: Complex.ZERO.pow(2.0) is NaN

### DIFF
--- a/src/main/java/org/apache/commons/math4/complex/Complex.java
+++ b/src/main/java/org/apache/commons/math4/complex/Complex.java
@@ -20,7 +20,6 @@ package org.apache.commons.math4.complex;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.commons.math4.FieldElement;
 import org.apache.commons.math4.exception.NotPositiveException;
 import org.apache.commons.math4.exception.NullArgumentException;
@@ -888,6 +887,15 @@ public class Complex implements FieldElement<Complex>, Serializable  {
     public Complex pow(Complex x)
         throws NullArgumentException {
         MathUtils.checkNotNull(x);
+        if (real == 0 && imaginary == 0) {
+            if (x.real > 0 && x.imaginary == 0) {
+                // 0 raised to positive number is 0
+                return ZERO;
+            } else {
+                // 0 raised to anything else is NaN
+                return NaN;
+            }
+        }
         return this.log().multiply(x).exp();
     }
 
@@ -899,6 +907,15 @@ public class Complex implements FieldElement<Complex>, Serializable  {
      * @see #pow(Complex)
      */
      public Complex pow(double x) {
+        if (real == 0 && imaginary == 0) {
+            if (x > 0) {
+                // 0 raised to positive number is 0
+                return ZERO;
+            } else {
+                // 0 raised to anything else is NaN
+                return NaN;
+            }
+        }
         return this.log().multiply(x).exp();
     }
 

--- a/src/test/java/org/apache/commons/math4/complex/ComplexTest.java
+++ b/src/test/java/org/apache/commons/math4/complex/ComplexTest.java
@@ -18,10 +18,7 @@
 package org.apache.commons.math4.complex;
 
 import java.util.List;
-
 import org.apache.commons.math4.TestUtils;
-import org.apache.commons.math4.complex.Complex;
-import org.apache.commons.math4.complex.ComplexUtils;
 import org.apache.commons.math4.exception.NullArgumentException;
 import org.apache.commons.math4.util.FastMath;
 import org.junit.Assert;
@@ -954,10 +951,14 @@ public class ComplexTest {
 
    @Test
    public void testPowZero() {
-       TestUtils.assertSame(Complex.NaN,
-               Complex.ZERO.pow(Complex.ONE));
+       TestUtils.assertEquals(Complex.ZERO,
+               Complex.ZERO.pow(Complex.ONE), 10e-12);
+       TestUtils.assertEquals(Complex.ZERO,
+               Complex.ZERO.pow(new Complex(2, 0)), 10e-12);
        TestUtils.assertSame(Complex.NaN,
                Complex.ZERO.pow(Complex.ZERO));
+       TestUtils.assertSame(Complex.NaN,
+               Complex.ZERO.pow(new Complex(-1, 0)));
        TestUtils.assertSame(Complex.NaN,
                Complex.ZERO.pow(Complex.I));
        TestUtils.assertEquals(Complex.ONE,
@@ -1012,8 +1013,10 @@ public class ComplexTest {
 
    @Test
    public void testScalarPowZero() {
-       TestUtils.assertSame(Complex.NaN, Complex.ZERO.pow(1.0));
+       TestUtils.assertEquals(Complex.ZERO, Complex.ZERO.pow(1.0), 10e-12);
+       TestUtils.assertEquals(Complex.ZERO, Complex.ZERO.pow(2.0), 10e-12);
        TestUtils.assertSame(Complex.NaN, Complex.ZERO.pow(0.0));
+       TestUtils.assertSame(Complex.NaN, Complex.ZERO.pow(-1.0));
        TestUtils.assertEquals(Complex.ONE, Complex.ONE.pow(0.0), 10e-12);
        TestUtils.assertEquals(Complex.ONE, Complex.I.pow(0.0), 10e-12);
        TestUtils.assertEquals(Complex.ONE, new Complex(-1, 3).pow(0.0), 10e-12);


### PR DESCRIPTION
Complex number 0 raised to a (real) positive number should be 0 and otherwise NaN.

Note I did have to change existing tests which asserted that 0^1 is NaN when computed by either varianr of Complex.pow().  I did some spelunking in the repository to find [the origin of those tests](https://git1-us-west.apache.org/repos/asf?p=commons-math.git;a=blobdiff;f=src/test/org/apache/commons/math/complex/ComplexTest.java;h=0ff1b4483054718ef626cfaa8985d3b87cbf1e90;hp=e8eb2664902f64f1984481b73f5a03cbbd34bd7c;hb=bdb18d5d10058c7614b6e394d5652bc620893a85;hpb=f033f293ec73679c3510e2cf051d27e2e2bb7068) but there were not any illuminating comments.

