### PR TITLE
Missing case in exception handling

### DIFF
--- a/src/main/java/org/apache/commons/math4/analysis/interpolation/PiecewiseBicubicSplineInterpolatingFunction.java
+++ b/src/main/java/org/apache/commons/math4/analysis/interpolation/PiecewiseBicubicSplineInterpolatingFunction.java
@@ -72,7 +72,7 @@ public class PiecewiseBicubicSplineInterpolatingFunction
         if (x == null ||
             y == null ||
             f == null ||
-            f[0] == null) {
+            (f.length > 0 && f[0] == null)) {
             throw new NullArgumentException();
         }
 


### PR DESCRIPTION
We are experimenting with a static analysis tool and it suggested this change to make the exception handling more robust.
The problem it reports is that f[0] is accessed in line 75, but in line 84 you actually check if f is empty and raise an exception.