### PR TITLE
Avoid manual array copy to increase the performance

### DIFF
--- a/src/main/java/org/apache/commons/math4/util/CombinatoricsUtils.java
+++ b/src/main/java/org/apache/commons/math4/util/CombinatoricsUtils.java
@@ -493,8 +493,8 @@ public final class CombinatoricsUtils {
                 cache.length : numValues;
 
             // Copy available values.
-            for (int i = beginCopy; i < endCopy; i++) {
-                LOG_FACTORIALS[i] = cache[i];
+            if (cache != null && endCopy != beginCopy) {
+                System.arraycopy(cache, beginCopy, LOG_FACTORIALS, beginCopy, endCopy - beginCopy);
             }
 
             // Precompute.


### PR DESCRIPTION
I am using this class for some heavy operation tasks and manual array copy is not helping us. I have tested this change and seems to bring in a minor improvement. And it does not break any existing code as well. 
