### PR TITLE
MATH-1413 add generics to the Frequency class

### DIFF
--- a/src/main/java/org/apache/commons/math4/stat/Frequency.java
+++ b/src/main/java/org/apache/commons/math4/stat/Frequency.java
@@ -28,7 +28,6 @@ import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import org.apache.commons.math4.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.exception.NullArgumentException;
 import org.apache.commons.math4.exception.util.LocalizedFormats;
 import org.apache.commons.math4.util.MathUtils;
@@ -36,39 +35,15 @@ import org.apache.commons.math4.util.MathUtils;
 /**
  * Maintains a frequency distribution.
  * <p>
- * Accepts int, long, char or Comparable values.  New values added must be
- * comparable to those that have been added, otherwise the add method will
- * throw an IllegalArgumentException.</p>
- * <p>
- * Integer values (int, long, Integer, Long) are not distinguished by type --
- * i.e. <code>addValue(Long.valueOf(2)), addValue(2), addValue(2l)</code> all have
- * the same effect (similarly for arguments to <code>getCount,</code> etc.).</p>
- * <p>NOTE: byte and short values will be implicitly converted to int values
- * by the compiler, thus there are no explicit overloaded methods for these
- * primitive types.</p>
- * <p>
- * char values are converted by <code>addValue</code> to Character instances.
- * As such, these values are not comparable to integral values, so attempts
- * to combine integral types with chars in a frequency distribution will fail.
- * </p>
- * <p>
- * Float is not coerced to Double.
- * Since they are not Comparable with each other the user must do any necessary coercion.
- * Float.NaN and Double.NaN are not treated specially; they may occur in input and will
- * occur in output if appropriate.
- * </b>
- * <p>
  * The values are ordered using the default (natural order), unless a
  * <code>Comparator</code> is supplied in the constructor.</p>
- *
  */
-public class Frequency implements Serializable {
+public class Frequency<T extends Comparable<T>> implements Serializable {
 
     /** Serializable version identifier */
-    private static final long serialVersionUID = -3845586908418844111L;
-
+    private static final long serialVersionUID = 605878194679954450L;
     /** underlying collection */
-    private final SortedMap<Comparable<?>, Long> freqTable;
+    private final SortedMap<T, Long> freqTable;
 
     /**
      * Default constructor.
@@ -82,9 +57,8 @@ public class Frequency implements Serializable {
      *
      * @param comparator Comparator used to order values
      */
-    @SuppressWarnings("unchecked") // TODO is the cast OK?
-    public Frequency(Comparator<?> comparator) {
-        freqTable = new TreeMap<>((Comparator<? super Comparable<?>>) comparator);
+    public Frequency(Comparator<T> comparator) {
+        freqTable = new TreeMap<>(comparator);
     }
 
     /**
@@ -97,9 +71,9 @@ public class Frequency implements Serializable {
         NumberFormat nf = NumberFormat.getPercentInstance();
         StringBuilder outBuffer = new StringBuilder();
         outBuffer.append("Value \t Freq. \t Pct. \t Cum Pct. \n");
-        Iterator<Comparable<?>> iter = freqTable.keySet().iterator();
+        Iterator<T> iter = freqTable.keySet().iterator();
         while (iter.hasNext()) {
-            Comparable<?> value = iter.next();
+            T value = iter.next();
             outBuffer.append(value);
             outBuffer.append('\t');
             outBuffer.append(getCount(value));
@@ -114,132 +88,27 @@ public class Frequency implements Serializable {
 
     /**
      * Adds 1 to the frequency count for v.
-     * <p>
-     * If other objects have already been added to this Frequency, v must
-     * be comparable to those that have already been added.
-     * </p>
      *
      * @param v the value to add.
-     * @throws MathIllegalArgumentException if <code>v</code> is not comparable with previous entries
      */
-    public void addValue(Comparable<?> v) throws MathIllegalArgumentException {
+    public void addValue(T v) {
         incrementValue(v, 1);
     }
 
     /**
-     * Adds 1 to the frequency count for v.
-     *
-     * @param v the value to add.
-     * @throws MathIllegalArgumentException if the table contains entries not
-     * comparable to Long
-     */
-    public void addValue(int v) throws MathIllegalArgumentException {
-        addValue(Long.valueOf(v));
-    }
-
-    /**
-     * Adds 1 to the frequency count for v.
-     *
-     * @param v the value to add.
-     * @throws MathIllegalArgumentException if the table contains entries not
-     * comparable to Long
-     */
-    public void addValue(long v) throws MathIllegalArgumentException {
-        addValue(Long.valueOf(v));
-    }
-
-    /**
-     * Adds 1 to the frequency count for v.
-     *
-     * @param v the value to add.
-     * @throws MathIllegalArgumentException if the table contains entries not
-     * comparable to Char
-     */
-    public void addValue(char v) throws MathIllegalArgumentException {
-        addValue(Character.valueOf(v));
-    }
-
-    /**
      * Increments the frequency count for v.
-     * <p>
-     * If other objects have already been added to this Frequency, v must
-     * be comparable to those that have already been added.
-     * </p>
      *
      * @param v the value to add.
      * @param increment the amount by which the value should be incremented
-     * @throws MathIllegalArgumentException if <code>v</code> is not comparable with previous entries
      * @since 3.1
      */
-    public void incrementValue(Comparable<?> v, long increment) throws MathIllegalArgumentException {
-        Comparable<?> obj = v;
-        if (v instanceof Integer) {
-            obj = Long.valueOf(((Integer) v).longValue());
+    public void incrementValue(T v, long increment) {
+        Long count = freqTable.get(v);
+        if (count == null) {
+            freqTable.put(v, Long.valueOf(increment));
+        } else {
+            freqTable.put(v, Long.valueOf(count.longValue() + increment));
         }
-        try {
-            Long count = freqTable.get(obj);
-            if (count == null) {
-                freqTable.put(obj, Long.valueOf(increment));
-            } else {
-                freqTable.put(obj, Long.valueOf(count.longValue() + increment));
-            }
-        } catch (ClassCastException ex) {
-            //TreeMap will throw ClassCastException if v is not comparable
-            throw new MathIllegalArgumentException(
-                  LocalizedFormats.INSTANCES_NOT_COMPARABLE_TO_EXISTING_VALUES,
-                  v.getClass().getName());
-        }
-    }
-
-    /**
-     * Increments the frequency count for v.
-     * <p>
-     * If other objects have already been added to this Frequency, v must
-     * be comparable to those that have already been added.
-     * </p>
-     *
-     * @param v the value to add.
-     * @param increment the amount by which the value should be incremented
-     * @throws MathIllegalArgumentException if the table contains entries not
-     * comparable to Long
-     * @since 3.3
-     */
-    public void incrementValue(int v, long increment) throws MathIllegalArgumentException {
-        incrementValue(Long.valueOf(v), increment);
-    }
-
-    /**
-     * Increments the frequency count for v.
-     * <p>
-     * If other objects have already been added to this Frequency, v must
-     * be comparable to those that have already been added.
-     * </p>
-     *
-     * @param v the value to add.
-     * @param increment the amount by which the value should be incremented
-     * @throws MathIllegalArgumentException if the table contains entries not
-     * comparable to Long
-     * @since 3.3
-     */
-    public void incrementValue(long v, long increment) throws MathIllegalArgumentException {
-        incrementValue(Long.valueOf(v), increment);
-    }
-
-    /**
-     * Increments the frequency count for v.
-     * <p>
-     * If other objects have already been added to this Frequency, v must
-     * be comparable to those that have already been added.
-     * </p>
-     *
-     * @param v the value to add.
-     * @param increment the amount by which the value should be incremented
-     * @throws MathIllegalArgumentException if the table contains entries not
-     * comparable to Char
-     * @since 3.3
-     */
-    public void incrementValue(char v, long increment) throws MathIllegalArgumentException {
-        incrementValue(Character.valueOf(v), increment);
     }
 
     /** Clears the frequency table */
@@ -249,14 +118,10 @@ public class Frequency implements Serializable {
 
     /**
      * Returns an Iterator over the set of values that have been added.
-     * <p>
-     * If added values are integral (i.e., integers, longs, Integers, or Longs),
-     * they are converted to Longs when they are added, so the objects returned
-     * by the Iterator will in this case be Longs.</p>
      *
      * @return values Iterator
      */
-    public Iterator<Comparable<?>> valuesIterator() {
+    public Iterator<T> valuesIterator() {
         return freqTable.keySet().iterator();
     }
 
@@ -265,15 +130,11 @@ public class Frequency implements Serializable {
      * Using the entry set to iterate is more efficient in the case where you
      * need to access respective counts as well as values, since it doesn't
      * require a "get" for every key...the value is provided in the Map.Entry.
-     * <p>
-     * If added values are integral (i.e., integers, longs, Integers, or Longs),
-     * they are converted to Longs when they are added, so the values of the
-     * map entries returned by the Iterator will in this case be Longs.</p>
      *
      * @return entry set Iterator
      * @since 3.1
      */
-    public Iterator<Map.Entry<Comparable<?>, Long>> entrySetIterator() {
+    public Iterator<Map.Entry<T, Long>> entrySetIterator() {
         return freqTable.entrySet().iterator();
     }
 
@@ -295,55 +156,17 @@ public class Frequency implements Serializable {
 
     /**
      * Returns the number of values equal to v.
-     * Returns 0 if the value is not comparable.
      *
      * @param v the value to lookup.
      * @return the frequency of v.
      */
-    public long getCount(Comparable<?> v) {
-        if (v instanceof Integer) {
-            return getCount(((Integer) v).longValue());
-        }
+    public long getCount(T v) {
         long result = 0;
-        try {
-            Long count =  freqTable.get(v);
-            if (count != null) {
-                result = count.longValue();
-            }
-        } catch (ClassCastException ex) { // NOPMD
-            // ignore and return 0 -- ClassCastException will be thrown if value is not comparable
+        Long count =  freqTable.get(v);
+        if (count != null) {
+            result = count.longValue();
         }
         return result;
-    }
-
-    /**
-     * Returns the number of values equal to v.
-     *
-     * @param v the value to lookup.
-     * @return the frequency of v.
-     */
-    public long getCount(int v) {
-        return getCount(Long.valueOf(v));
-    }
-
-    /**
-     * Returns the number of values equal to v.
-     *
-     * @param v the value to lookup.
-     * @return the frequency of v.
-     */
-    public long getCount(long v) {
-        return getCount(Long.valueOf(v));
-    }
-
-    /**
-     * Returns the number of values equal to v.
-     *
-     * @param v the value to lookup.
-     * @return the frequency of v.
-     */
-    public long getCount(char v) {
-        return getCount(Character.valueOf(v));
     }
 
     /**
@@ -361,13 +184,12 @@ public class Frequency implements Serializable {
      * (as a proportion between 0 and 1).
      * <p>
      * Returns <code>Double.NaN</code> if no values have been added.
-     * Returns 0 if at least one value has been added, but v is not comparable
-     * to the values set.</p>
+     * </p>
      *
      * @param v the value to lookup
      * @return the proportion of values equal to v
      */
-    public double getPct(Comparable<?> v) {
+    public double getPct(T v) {
         final long sumFreq = getSumFreq();
         if (sumFreq == 0) {
             return Double.NaN;
@@ -375,70 +197,27 @@ public class Frequency implements Serializable {
         return (double) getCount(v) / (double) sumFreq;
     }
 
-    /**
-     * Returns the percentage of values that are equal to v
-     * (as a proportion between 0 and 1).
-     *
-     * @param v the value to lookup
-     * @return the proportion of values equal to v
-     */
-    public double getPct(int v) {
-        return getPct(Long.valueOf(v));
-    }
-
-    /**
-     * Returns the percentage of values that are equal to v
-     * (as a proportion between 0 and 1).
-     *
-     * @param v the value to lookup
-     * @return the proportion of values equal to v
-     */
-    public double getPct(long v) {
-        return getPct(Long.valueOf(v));
-    }
-
-    /**
-     * Returns the percentage of values that are equal to v
-     * (as a proportion between 0 and 1).
-     *
-     * @param v the value to lookup
-     * @return the proportion of values equal to v
-     */
-    public double getPct(char v) {
-        return getPct(Character.valueOf(v));
-    }
-
     //-----------------------------------------------------------------------------------------
 
     /**
      * Returns the cumulative frequency of values less than or equal to v.
-     * <p>
-     * Returns 0 if v is not comparable to the values set.</p>
      *
      * @param v the value to lookup.
      * @return the proportion of values equal to v
      */
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    public long getCumFreq(Comparable<?> v) {
+    public long getCumFreq(T v) {
         if (getSumFreq() == 0) {
             return 0;
         }
-        if (v instanceof Integer) {
-            return getCumFreq(((Integer) v).longValue());
-        }
-        Comparator<Comparable<?>> c = (Comparator<Comparable<?>>) freqTable.comparator();
+        Comparator<? super T> c = freqTable.comparator();
         if (c == null) {
-            c = new NaturalComparator();
+            c = new NaturalComparator<T>();
         }
         long result = 0;
 
-        try {
-            Long value = freqTable.get(v);
-            if (value != null) {
-                result = value.longValue();
-            }
-        } catch (ClassCastException ex) {
-            return result;   // v is not comparable
+        Long value = freqTable.get(v);
+        if (value != null) {
+            result = value.longValue();
         }
 
         if (c.compare(v, freqTable.firstKey()) < 0) {
@@ -449,9 +228,9 @@ public class Frequency implements Serializable {
             return getSumFreq();    // v is comparable, but greater than the last value
         }
 
-        Iterator<Comparable<?>> values = valuesIterator();
+        Iterator<T> values = valuesIterator();
         while (values.hasNext()) {
-            Comparable<?> nextValue = values.next();
+            T nextValue = values.next();
             if (c.compare(v, nextValue) > 0) {
                 result += getCount(nextValue);
             } else {
@@ -461,42 +240,6 @@ public class Frequency implements Serializable {
         return result;
     }
 
-     /**
-     * Returns the cumulative frequency of values less than or equal to v.
-     * <p>
-     * Returns 0 if v is not comparable to the values set.</p>
-     *
-     * @param v the value to lookup
-     * @return the proportion of values equal to v
-     */
-    public long getCumFreq(int v) {
-        return getCumFreq(Long.valueOf(v));
-    }
-
-     /**
-     * Returns the cumulative frequency of values less than or equal to v.
-     * <p>
-     * Returns 0 if v is not comparable to the values set.</p>
-     *
-     * @param v the value to lookup
-     * @return the proportion of values equal to v
-     */
-    public long getCumFreq(long v) {
-        return getCumFreq(Long.valueOf(v));
-    }
-
-    /**
-     * Returns the cumulative frequency of values less than or equal to v.
-     * <p>
-     * Returns 0 if v is not comparable to the values set.</p>
-     *
-     * @param v the value to lookup
-     * @return the proportion of values equal to v
-     */
-    public long getCumFreq(char v) {
-        return getCumFreq(Character.valueOf(v));
-    }
-
     //----------------------------------------------------------------------------------------------
 
     /**
@@ -504,13 +247,12 @@ public class Frequency implements Serializable {
      * (as a proportion between 0 and 1).
      * <p>
      * Returns <code>Double.NaN</code> if no values have been added.
-     * Returns 0 if at least one value has been added, but v is not comparable
-     * to the values set.</p>
+     * </p>
      *
      * @param v the value to lookup
      * @return the proportion of values less than or equal to v
      */
-    public double getCumPct(Comparable<?> v) {
+    public double getCumPct(T v) {
         final long sumFreq = getSumFreq();
         if (sumFreq == 0) {
             return Double.NaN;
@@ -519,51 +261,12 @@ public class Frequency implements Serializable {
     }
 
     /**
-     * Returns the cumulative percentage of values less than or equal to v
-     * (as a proportion between 0 and 1).
-     * <p>
-     * Returns 0 if v is not comparable to the values set.</p>
-     *
-     * @param v the value to lookup
-     * @return the proportion of values less than or equal to v
-     */
-    public double getCumPct(int v) {
-        return getCumPct(Long.valueOf(v));
-    }
-
-    /**
-     * Returns the cumulative percentage of values less than or equal to v
-     * (as a proportion between 0 and 1).
-     * <p>
-     * Returns 0 if v is not comparable to the values set.</p>
-     *
-     * @param v the value to lookup
-     * @return the proportion of values less than or equal to v
-     */
-    public double getCumPct(long v) {
-        return getCumPct(Long.valueOf(v));
-    }
-
-    /**
-     * Returns the cumulative percentage of values less than or equal to v
-     * (as a proportion between 0 and 1).
-     * <p>
-     * Returns 0 if v is not comparable to the values set.</p>
-     *
-     * @param v the value to lookup
-     * @return the proportion of values less than or equal to v
-     */
-    public double getCumPct(char v) {
-        return getCumPct(Character.valueOf(v));
-    }
-
-    /**
      * Returns the mode value(s) in comparator order.
      *
      * @return a list containing the value(s) which appear most often.
      * @since 3.3
      */
-    public List<Comparable<?>> getMode() {
+    public List<T> getMode() {
         long mostPopular = 0; // frequencies are always positive
 
         // Get the max count first, so we avoid having to recreate the List each time
@@ -574,8 +277,8 @@ public class Frequency implements Serializable {
             }
         }
 
-        List<Comparable<?>> modeList = new ArrayList<>();
-        for (Entry<Comparable<?>, Long> ent : freqTable.entrySet()) {
+        List<T> modeList = new ArrayList<>();
+        for (Entry<T, Long> ent : freqTable.entrySet()) {
             long frequency = ent.getValue().longValue();
             if (frequency == mostPopular) {
                modeList.add(ent.getKey());
@@ -595,12 +298,12 @@ public class Frequency implements Serializable {
      * @throws NullArgumentException if {@code other} is null
      * @since 3.1
      */
-    public void merge(final Frequency other) throws NullArgumentException {
+    public void merge(final Frequency<T> other) throws NullArgumentException {
         MathUtils.checkNotNull(other, LocalizedFormats.NULL_NOT_ALLOWED);
 
-        final Iterator<Map.Entry<Comparable<?>, Long>> iter = other.entrySetIterator();
+        final Iterator<Map.Entry<T, Long>> iter = other.entrySetIterator();
         while (iter.hasNext()) {
-            final Map.Entry<Comparable<?>, Long> entry = iter.next();
+            final Map.Entry<T, Long> entry = iter.next();
             incrementValue(entry.getKey(), entry.getValue().longValue());
         }
     }
@@ -614,10 +317,10 @@ public class Frequency implements Serializable {
      * @throws NullArgumentException if the collection is null
      * @since 3.1
      */
-    public void merge(final Collection<Frequency> others) throws NullArgumentException {
+    public void merge(final Collection<Frequency<T>> others) throws NullArgumentException {
         MathUtils.checkNotNull(others, LocalizedFormats.NULL_NOT_ALLOWED);
 
-        for (final Frequency freq : others) {
+        for (final Frequency<T> freq : others) {
             merge(freq);
         }
     }
@@ -626,10 +329,10 @@ public class Frequency implements Serializable {
 
     /**
      * A Comparator that compares comparable objects using the
-     * natural order.  Copied from Commons Collections ComparableComparator.
+     * natural order. Copied from Commons Collections ComparableComparator.
      * @param <T> the type of the objects compared
      */
-    private static class NaturalComparator<T extends Comparable<T>> implements Comparator<Comparable<T>>, Serializable {
+    private static class NaturalComparator<U extends Comparable<U>> implements Comparator<U>, Serializable {
 
         /** Serializable version identifier */
         private static final long serialVersionUID = -3852193713161395148L;
@@ -644,13 +347,10 @@ public class Frequency implements Serializable {
          * @return  result of comparison
          * @throws NullPointerException when <i>o1</i> is <code>null</code>,
          *         or when <code>((Comparable)o1).compareTo(o2)</code> does
-         * @throws ClassCastException when <i>o1</i> is not a {@link Comparable Comparable},
-         *         or when <code>((Comparable)o1).compareTo(o2)</code> does
          */
         @Override
-        @SuppressWarnings("unchecked") // cast to (T) may throw ClassCastException, see Javadoc
-        public int compare(Comparable<T> o1, Comparable<T> o2) {
-            return o1.compareTo((T) o2);
+        public int compare(U o1, U o2) {
+            return o1.compareTo(o2);
         }
     }
 
@@ -670,10 +370,10 @@ public class Frequency implements Serializable {
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof Frequency)) {
+        if (!(obj instanceof Frequency<?>)) {
             return false;
         }
-        Frequency other = (Frequency) obj;
+        Frequency<?> other = (Frequency<?>) obj;
         if (freqTable == null) {
             if (other.freqTable != null) {
                 return false;

--- a/src/main/java/org/apache/commons/math4/stat/StatUtils.java
+++ b/src/main/java/org/apache/commons/math4/stat/StatUtils.java
@@ -847,19 +847,19 @@ public final class StatUtils {
      */
     private static double[] getMode(double[] values, final int begin, final int length) {
         // Add the values to the frequency table
-        Frequency freq = new Frequency();
+        Frequency<Double> freq = new Frequency<>();
         for (int i = begin; i < begin + length; i++) {
             final double value = values[i];
             if (!Double.isNaN(value)) {
                 freq.addValue(Double.valueOf(value));
             }
         }
-        List<Comparable<?>> list = freq.getMode();
+        List<Double> list = freq.getMode();
         // Convert the list to an array of primitive double
         double[] modes = new double[list.size()];
         int i = 0;
-        for(Comparable<?> c : list) {
-            modes[i++] = ((Double) c).doubleValue();
+        for(Double c : list) {
+            modes[i++] = c.doubleValue();
         }
         return modes;
     }

--- a/src/test/java/org/apache/commons/math4/random/RandomUtilsDataGeneratorAbstractTest.java
+++ b/src/test/java/org/apache/commons/math4/random/RandomUtilsDataGeneratorAbstractTest.java
@@ -20,7 +20,6 @@ import org.apache.commons.math4.RetryRunner;
 import org.apache.commons.math4.TestUtils;
 import org.apache.commons.math4.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.stat.Frequency;
-import org.apache.commons.math4.stat.inference.ChiSquareTest;
 import org.apache.commons.math4.util.FastMath;
 import org.apache.commons.rng.UniformRandomProvider;
 import org.junit.Assert;
@@ -33,11 +32,8 @@ import org.junit.runner.RunWith;
 @RunWith(RetryRunner.class)
 public abstract class RandomUtilsDataGeneratorAbstractTest {
     private final long smallSampleSize = 1000;
-    private final double[] expected = { 250, 250, 250, 250 };
-    private final int largeSampleSize = 10000;
     private final String[] hex = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
                                    "a", "b", "c", "d", "e", "f" };
-    private final ChiSquareTest testStatistic = new ChiSquareTest();
     /** Data generator. */
     private final RandomUtils.DataGenerator randomData;
 
@@ -103,7 +99,7 @@ public abstract class RandomUtilsDataGeneratorAbstractTest {
     }
 
     private void checkNextLongUniform(long min, long max) {
-        final Frequency freq = new Frequency();
+        final Frequency<Long> freq = new Frequency<>();
         for (int i = 0; i < smallSampleSize; i++) {
             final long value = randomData.nextLong(min, max);
             Assert.assertTrue("nextLong range: " + value + " " + min + " " + max,
@@ -181,7 +177,7 @@ public abstract class RandomUtilsDataGeneratorAbstractTest {
         } catch (MathIllegalArgumentException ex) {
             // ignored
         }
-        Frequency f = new Frequency();
+        Frequency<String> f = new Frequency<>();
         for (int i = 0; i < smallSampleSize; i++) {
             hexString = randomData.nextHexString(100, useSha1);
             if (hexString.length() != 100) {
@@ -272,7 +268,7 @@ public abstract class RandomUtilsDataGeneratorAbstractTest {
             binBounds[i] = binBounds[i - 1] + binSize;  // + instead of * to avoid overflow in extreme case
         }
 
-        final Frequency freq = new Frequency();
+        final Frequency<Integer> freq = new Frequency<>();
         for (int i = 0; i < smallSampleSize; i++) {
             final double value = randomData.nextUniform(min, max);
             Assert.assertTrue("nextUniform range", (value > min) && (value < max));

--- a/src/test/java/org/apache/commons/math4/stat/FrequencyTest.java
+++ b/src/test/java/org/apache/commons/math4/stat/FrequencyTest.java
@@ -23,10 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.commons.math4.TestUtils;
-import org.apache.commons.math4.exception.MathIllegalArgumentException;
-import org.apache.commons.math4.stat.Frequency;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -41,175 +38,116 @@ public final class FrequencyTest {
     private static final int TWO = 2;
     private static final int THREE = 3 ;
     private static final double TOLERANCE = 10E-15d;
-    private static final char CHAR_A = 'a';
-
-    private Frequency f = null;
-
-    @Before
-    public void setUp() {
-        f = new Frequency();
-    }
 
     /** test freq counts */
     @Test
     public void testCounts() {
-        Assert.assertEquals("total count",0,f.getSumFreq());
-        f.addValue(ONE_LONG);
-        f.addValue(TWO_LONG);
-        f.addValue(1);
-        f.addValue(ONE);
-        Assert.assertEquals("one frequency count",3,f.getCount(1));
-        Assert.assertEquals("two frequency count",1,f.getCount(2));
-        Assert.assertEquals("three frequency count",0,f.getCount(3));
-        Assert.assertEquals("total count",4,f.getSumFreq());
-        Assert.assertEquals("zero cumulative frequency", 0, f.getCumFreq(0));
-        Assert.assertEquals("one cumulative frequency", 3,  f.getCumFreq(1));
-        Assert.assertEquals("two cumulative frequency", 4,  f.getCumFreq(2));
-        Assert.assertEquals("Integer argument cum freq",4, f.getCumFreq(Integer.valueOf(2)));
-        Assert.assertEquals("five cumulative frequency", 4,  f.getCumFreq(5));
-        Assert.assertEquals("foo cumulative frequency", 0,  f.getCumFreq("foo"));
+        Frequency<Long> fLong = new Frequency<>();
+        Assert.assertEquals("total count",0,fLong.getSumFreq());
+        fLong.addValue(ONE_LONG);
+        fLong.addValue(TWO_LONG);
+        fLong.addValue(1l);
+        fLong.addValue(ONE_LONG);
+        Assert.assertEquals("one frequency count",3,fLong.getCount(1l));
+        Assert.assertEquals("two frequency count",1,fLong.getCount(2l));
+        Assert.assertEquals("three frequency count",0,fLong.getCount(3l));
+        Assert.assertEquals("total count",4,fLong.getSumFreq());
+        Assert.assertEquals("zero cumulative frequency", 0, fLong.getCumFreq(0l));
+        Assert.assertEquals("one cumulative frequency", 3,  fLong.getCumFreq(1l));
+        Assert.assertEquals("two cumulative frequency", 4,  fLong.getCumFreq(2l));
+        Assert.assertEquals("Integer argument cum freq",4, fLong.getCumFreq(Long.valueOf(2)));
+        Assert.assertEquals("five cumulative frequency", 4,  fLong.getCumFreq(5l));
+        Assert.assertEquals("foo cumulative frequency", 0,  fLong.getCumFreq(-1l));
 
-        f.clear();
-        Assert.assertEquals("total count",0,f.getSumFreq());
+        fLong.clear();
+        Assert.assertEquals("total count",0,fLong.getSumFreq());
 
         // userguide examples -------------------------------------------------------------------
-        f.addValue("one");
-        f.addValue("One");
-        f.addValue("oNe");
-        f.addValue("Z");
-        Assert.assertEquals("one cumulative frequency", 1 ,  f.getCount("one"));
-        Assert.assertEquals("Z cumulative pct", 0.5,  f.getCumPct("Z"), TOLERANCE);
-        Assert.assertEquals("z cumulative pct", 1.0,  f.getCumPct("z"), TOLERANCE);
-        Assert.assertEquals("Ot cumulative pct", 0.25,  f.getCumPct("Ot"), TOLERANCE);
-        f.clear();
+        Frequency<String> fString = new Frequency<>();
+        fString.addValue("one");
+        fString.addValue("One");
+        fString.addValue("oNe");
+        fString.addValue("Z");
+        Assert.assertEquals("one cumulative frequency", 1 , fString.getCount("one"));
+        Assert.assertEquals("Z cumulative pct", 0.5,  fString.getCumPct("Z"), TOLERANCE);
+        Assert.assertEquals("z cumulative pct", 1.0,  fString.getCumPct("z"), TOLERANCE);
+        Assert.assertEquals("Ot cumulative pct", 0.25,  fString.getCumPct("Ot"), TOLERANCE);
 
-        f = null;
-        Frequency f = new Frequency();
-        f.addValue(1);
-        f.addValue(Integer.valueOf(1));
-        f.addValue(Long.valueOf(1));
-        f.addValue(2);
-        f.addValue(Integer.valueOf(-1));
-        Assert.assertEquals("1 count", 3, f.getCount(1));
-        Assert.assertEquals("1 count", 3, f.getCount(Integer.valueOf(1)));
-        Assert.assertEquals("0 cum pct", 0.2, f.getCumPct(0), TOLERANCE);
-        Assert.assertEquals("1 pct", 0.6, f.getPct(Integer.valueOf(1)), TOLERANCE);
-        Assert.assertEquals("-2 cum pct", 0, f.getCumPct(-2), TOLERANCE);
-        Assert.assertEquals("10 cum pct", 1, f.getCumPct(10), TOLERANCE);
+        Frequency<Integer> fInteger = new Frequency<>();
+        fInteger.addValue(1);
+        fInteger.addValue(Integer.valueOf(1));
+        fInteger.addValue(ONE);
+        fInteger.addValue(2);
+        fInteger.addValue(Integer.valueOf(-1));
+        Assert.assertEquals("1 count", 3, fInteger.getCount(1));
+        Assert.assertEquals("1 count", 3, fInteger.getCount(Integer.valueOf(1)));
+        Assert.assertEquals("0 cum pct", 0.2, fInteger.getCumPct(0), TOLERANCE);
+        Assert.assertEquals("1 pct", 0.6, fInteger.getPct(Integer.valueOf(1)), TOLERANCE);
+        Assert.assertEquals("-2 cum pct", 0, fInteger.getCumPct(-2), TOLERANCE);
+        Assert.assertEquals("10 cum pct", 1, fInteger.getCumPct(10), TOLERANCE);
 
-        f = null;
-        f = new Frequency(String.CASE_INSENSITIVE_ORDER);
-        f.addValue("one");
-        f.addValue("One");
-        f.addValue("oNe");
-        f.addValue("Z");
-        Assert.assertEquals("one count", 3 ,  f.getCount("one"));
-        Assert.assertEquals("Z cumulative pct -- case insensitive", 1 ,  f.getCumPct("Z"), TOLERANCE);
-        Assert.assertEquals("z cumulative pct -- case insensitive", 1 ,  f.getCumPct("z"), TOLERANCE);
+        fString = new Frequency<String>(String.CASE_INSENSITIVE_ORDER);
+        fString.addValue("one");
+        fString.addValue("One");
+        fString.addValue("oNe");
+        fString.addValue("Z");
+        Assert.assertEquals("one count", 3 ,  fString.getCount("one"));
+        Assert.assertEquals("Z cumulative pct -- case insensitive", 1 ,  fString.getCumPct("Z"), TOLERANCE);
+        Assert.assertEquals("z cumulative pct -- case insensitive", 1 ,  fString.getCumPct("z"), TOLERANCE);
 
-        f = null;
-        f = new Frequency();
-        Assert.assertEquals(0L, f.getCount('a'));
-        Assert.assertEquals(0L, f.getCumFreq('b'));
-        TestUtils.assertEquals(Double.NaN, f.getPct('a'), 0.0);
-        TestUtils.assertEquals(Double.NaN, f.getCumPct('b'), 0.0);
-        f.addValue('a');
-        f.addValue('b');
-        f.addValue('c');
-        f.addValue('d');
-        Assert.assertEquals(1L, f.getCount('a'));
-        Assert.assertEquals(2L, f.getCumFreq('b'));
-        Assert.assertEquals(0.25, f.getPct('a'), 0.0);
-        Assert.assertEquals(0.5, f.getCumPct('b'), 0.0);
-        Assert.assertEquals(1.0, f.getCumPct('e'), 0.0);
+        Frequency<Character> fChar = new Frequency<>();
+        Assert.assertEquals(0L, fChar.getCount('a'));
+        Assert.assertEquals(0L, fChar.getCumFreq('b'));
+        TestUtils.assertEquals(Double.NaN, fChar.getPct('a'), 0.0);
+        TestUtils.assertEquals(Double.NaN, fChar.getCumPct('b'), 0.0);
+        fChar.addValue('a');
+        fChar.addValue('b');
+        fChar.addValue('c');
+        fChar.addValue('d');
+        Assert.assertEquals(1L, fChar.getCount('a'));
+        Assert.assertEquals(2L, fChar.getCumFreq('b'));
+        Assert.assertEquals(0.25, fChar.getPct('a'), 0.0);
+        Assert.assertEquals(0.5, fChar.getCumPct('b'), 0.0);
+        Assert.assertEquals(1.0, fChar.getCumPct('e'), 0.0);
     }
 
     /** test pcts */
     @Test
     public void testPcts() {
+        Frequency<Long> f = new Frequency<>();
         f.addValue(ONE_LONG);
         f.addValue(TWO_LONG);
-        f.addValue(ONE);
-        f.addValue(TWO);
         f.addValue(THREE_LONG);
         f.addValue(THREE_LONG);
-        f.addValue(3);
-        f.addValue(THREE);
-        Assert.assertEquals("one pct",0.25,f.getPct(1),TOLERANCE);
         Assert.assertEquals("two pct",0.25,f.getPct(Long.valueOf(2)),TOLERANCE);
-        Assert.assertEquals("three pct",0.5,f.getPct(THREE_LONG),TOLERANCE);
-        Assert.assertEquals("five pct",0,f.getPct(5),TOLERANCE);
-        Assert.assertEquals("foo pct",0,f.getPct("foo"),TOLERANCE);
-        Assert.assertEquals("one cum pct",0.25,f.getCumPct(1),TOLERANCE);
         Assert.assertEquals("two cum pct",0.50,f.getCumPct(Long.valueOf(2)),TOLERANCE);
-        Assert.assertEquals("Integer argument",0.50,f.getCumPct(Integer.valueOf(2)),TOLERANCE);
         Assert.assertEquals("three cum pct",1.0,f.getCumPct(THREE_LONG),TOLERANCE);
-        Assert.assertEquals("five cum pct",1.0,f.getCumPct(5),TOLERANCE);
-        Assert.assertEquals("zero cum pct",0.0,f.getCumPct(0),TOLERANCE);
-        Assert.assertEquals("foo cum pct",0,f.getCumPct("foo"),TOLERANCE);
     }
 
     /** test adding incomparable values */
     @Test
     public void testAdd() {
+        Frequency<Character> f = new Frequency<>();
         char aChar = 'a';
         char bChar = 'b';
-        String aString = "a";
         f.addValue(aChar);
         f.addValue(bChar);
-        try {
-            f.addValue(aString);
-            Assert.fail("Expecting MathIllegalArgumentException");
-        } catch (MathIllegalArgumentException ex) {
-            // expected
-        }
-        try {
-            f.addValue(2);
-            Assert.fail("Expecting MathIllegalArgumentException");
-        } catch (MathIllegalArgumentException ex) {
-            // expected
-        }
         Assert.assertEquals("a pct",0.5,f.getPct(aChar),TOLERANCE);
         Assert.assertEquals("b cum pct",1.0,f.getCumPct(bChar),TOLERANCE);
-        Assert.assertEquals("a string pct",0.0,f.getPct(aString),TOLERANCE);
-        Assert.assertEquals("a string cum pct",0.0,f.getCumPct(aString),TOLERANCE);
-
-        f = new Frequency();
-        f.addValue("One");
-        try {
-            f.addValue(new Integer("One"));
-            Assert.fail("Expecting IllegalArgumentException");
-        } catch (IllegalArgumentException ex) {
-            // expected
-        }
     }
 
     /** test empty table */
     @Test
     public void testEmptyTable() {
+        Frequency<Integer> f = new Frequency<>();
         Assert.assertEquals("freq sum, empty table", 0, f.getSumFreq());
         Assert.assertEquals("count, empty table", 0, f.getCount(0));
         Assert.assertEquals("count, empty table",0, f.getCount(Integer.valueOf(0)));
         Assert.assertEquals("cum freq, empty table", 0, f.getCumFreq(0));
-        Assert.assertEquals("cum freq, empty table", 0, f.getCumFreq("x"));
         Assert.assertTrue("pct, empty table", Double.isNaN(f.getPct(0)));
         Assert.assertTrue("pct, empty table", Double.isNaN(f.getPct(Integer.valueOf(0))));
         Assert.assertTrue("cum pct, empty table", Double.isNaN(f.getCumPct(0)));
         Assert.assertTrue("cum pct, empty table", Double.isNaN(f.getCumPct(Integer.valueOf(0))));
-    }
-
-    @Test
-    public void testNonComparableCumPct() {
-        f.addValue("a");
-        Assert.assertEquals("cum freq, single entry", 1.0d, f.getCumPct("a"),TOLERANCE);
-        Assert.assertEquals("cum freq, single entry non comparable", 0.0d, f.getCumPct(100),TOLERANCE);
-    }
-
-    @Test
-    public void testNonComparablePct() {
-        f.addValue("a");
-        Assert.assertEquals("cum freq, single entry", 1.0d, f.getPct("a"),TOLERANCE);
-        Assert.assertEquals("cum freq, single entry non comparable", 0.0d, f.getPct(100),TOLERANCE);
     }
 
     /**
@@ -217,10 +155,9 @@ public final class FrequencyTest {
      */
     @Test
     public void testToString() throws Exception {
+        Frequency<Long> f = new Frequency<>();
         f.addValue(ONE_LONG);
         f.addValue(TWO_LONG);
-        f.addValue(ONE);
-        f.addValue(TWO);
 
         String s = f.toString();
         //System.out.println(s);
@@ -231,28 +168,18 @@ public final class FrequencyTest {
 
         line = reader.readLine(); // one's or two's line
         Assert.assertNotNull(line);
-
-        line = reader.readLine(); // one's or two's line
-        Assert.assertNotNull(line);
-
-        line = reader.readLine(); // no more elements
-        Assert.assertNull(line);
     }
 
     @Test
     public void testIntegerValues() {
-        Comparable<?> obj1 = null;
-        obj1 = Integer.valueOf(1);
-        Integer int1 = Integer.valueOf(1);
-        f.addValue(obj1);
-        f.addValue(int1);
+        Frequency<Integer> f = new Frequency<>();
+        f.addValue(Integer.valueOf(1));
+        f.addValue(1);
         f.addValue(2);
-        f.addValue(Long.valueOf(2));
+        f.addValue(Integer.valueOf(2));
         Assert.assertEquals("Integer 1 count", 2, f.getCount(1));
         Assert.assertEquals("Integer 1 count", 2, f.getCount(Integer.valueOf(1)));
-        Assert.assertEquals("Integer 1 count", 2, f.getCount(Long.valueOf(1)));
         Assert.assertEquals("Integer 1 cumPct", 0.5, f.getCumPct(1), TOLERANCE);
-        Assert.assertEquals("Integer 1 cumPct", 0.5, f.getCumPct(Long.valueOf(1)), TOLERANCE);
         Assert.assertEquals("Integer 1 cumPct", 0.5, f.getCumPct(Integer.valueOf(1)), TOLERANCE);
 
         f.incrementValue(ONE, -2);
@@ -263,14 +190,13 @@ public final class FrequencyTest {
 
         Iterator<?> it = f.valuesIterator();
         while (it.hasNext()) {
-            Assert.assertTrue(it.next() instanceof Long);
+            Assert.assertTrue(it.next() instanceof Integer);
         }
     }
 
     @Test
     public void testSerial() {
-        f.addValue(ONE_LONG);
-        f.addValue(TWO_LONG);
+        Frequency<Integer> f = new Frequency<>();
         f.addValue(ONE);
         f.addValue(TWO);
         Assert.assertEquals(f, TestUtils.serializeAndRecover(f));
@@ -278,17 +204,19 @@ public final class FrequencyTest {
 
     @Test
     public void testGetUniqueCount() {
+        Frequency<Long> f = new Frequency<>();
         Assert.assertEquals(0, f.getUniqueCount());
         f.addValue(ONE_LONG);
         Assert.assertEquals(1, f.getUniqueCount());
         f.addValue(ONE_LONG);
         Assert.assertEquals(1, f.getUniqueCount());
-        f.addValue(TWO);
+        f.addValue(TWO_LONG);
         Assert.assertEquals(2, f.getUniqueCount());
     }
 
     @Test
     public void testIncrement() {
+        Frequency<Long> f = new Frequency<>();
         Assert.assertEquals(0, f.getUniqueCount());
         f.incrementValue(ONE_LONG, 1);
         Assert.assertEquals(1, f.getCount(ONE_LONG));
@@ -298,89 +226,69 @@ public final class FrequencyTest {
 
         f.incrementValue(ONE_LONG, -5);
         Assert.assertEquals(0, f.getCount(ONE_LONG));
-
-        try {
-            f.incrementValue(CHAR_A, 1);
-            Assert.fail("Expecting MathIllegalArgumentException");
-        } catch (MathIllegalArgumentException ex) {
-            // expected
-        }
-
-        f = new Frequency();
-        f.incrementValue(CHAR_A, 2);
-
-        Assert.assertEquals(2, f.getCount(CHAR_A));
-
-        try {
-            f.incrementValue(ONE, 1);
-            Assert.fail("Expecting MathIllegalArgumentException");
-        } catch (MathIllegalArgumentException ex) {
-            // expected
-        }
-
-        f.incrementValue(CHAR_A, 3);
-        Assert.assertEquals(5, f.getCount(CHAR_A));
-
     }
 
     @Test
     public void testMerge() {
+        Frequency<Long> f = new Frequency<>();
         Assert.assertEquals(0, f.getUniqueCount());
         f.addValue(ONE_LONG);
         f.addValue(TWO_LONG);
-        f.addValue(ONE);
-        f.addValue(TWO);
+        f.addValue(ONE_LONG);
+        f.addValue(TWO_LONG);
 
         Assert.assertEquals(2, f.getUniqueCount());
-        Assert.assertEquals(2, f.getCount(ONE));
-        Assert.assertEquals(2, f.getCount(TWO));
+        Assert.assertEquals(2, f.getCount(ONE_LONG));
+        Assert.assertEquals(2, f.getCount(TWO_LONG));
 
-        Frequency g = new Frequency();
+        Frequency<Long> g = new Frequency<>();
         g.addValue(ONE_LONG);
         g.addValue(THREE_LONG);
-        g.addValue(THREE);
+        g.addValue(THREE_LONG);
 
         Assert.assertEquals(2, g.getUniqueCount());
-        Assert.assertEquals(1, g.getCount(ONE));
-        Assert.assertEquals(2, g.getCount(THREE));
+        Assert.assertEquals(1, g.getCount(ONE_LONG));
+        Assert.assertEquals(2, g.getCount(THREE_LONG));
 
         f.merge(g);
 
         Assert.assertEquals(3, f.getUniqueCount());
-        Assert.assertEquals(3, f.getCount(ONE));
-        Assert.assertEquals(2, f.getCount(TWO));
-        Assert.assertEquals(2, f.getCount(THREE));
+        Assert.assertEquals(3, f.getCount(ONE_LONG));
+        Assert.assertEquals(2, f.getCount(TWO_LONG));
+        Assert.assertEquals(2, f.getCount(THREE_LONG));
     }
 
     @Test
     public void testMergeCollection() {
+        Frequency<Long> f = new Frequency<>();
         Assert.assertEquals(0, f.getUniqueCount());
         f.addValue(ONE_LONG);
 
         Assert.assertEquals(1, f.getUniqueCount());
-        Assert.assertEquals(1, f.getCount(ONE));
-        Assert.assertEquals(0, f.getCount(TWO));
+        Assert.assertEquals(1, f.getCount(ONE_LONG));
+        Assert.assertEquals(0, f.getCount(TWO_LONG));
 
-        Frequency g = new Frequency();
+        Frequency<Long> g = new Frequency<Long>();
         g.addValue(TWO_LONG);
 
-        Frequency h = new Frequency();
+        Frequency<Long> h = new Frequency<Long>();
         h.addValue(THREE_LONG);
 
-        List<Frequency> coll = new ArrayList<>();
+        List<Frequency<Long>> coll = new ArrayList<>();
         coll.add(g);
         coll.add(h);
         f.merge(coll);
 
         Assert.assertEquals(3, f.getUniqueCount());
-        Assert.assertEquals(1, f.getCount(ONE));
-        Assert.assertEquals(1, f.getCount(TWO));
-        Assert.assertEquals(1, f.getCount(THREE));
+        Assert.assertEquals(1, f.getCount(ONE_LONG));
+        Assert.assertEquals(1, f.getCount(TWO_LONG));
+        Assert.assertEquals(1, f.getCount(THREE_LONG));
     }
 
     @Test
     public void testMode() {
-        List<Comparable<?>> mode;
+        Frequency<String> f = new Frequency<>();
+        List<String> mode;
         mode = f.getMode();
         Assert.assertEquals(0, mode.size());
 
@@ -401,18 +309,12 @@ public final class FrequencyTest {
         Assert.assertEquals("2", mode.get(0));
         Assert.assertFalse(mode.contains("1"));
         Assert.assertTrue(mode.contains("2"));
-
-        try {
-            f.addValue(Double.valueOf(Double.NaN));
-            Assert.fail("Expected MathIllegalArgumentException");
-        } catch (MathIllegalArgumentException e) {
-            // expected
-        }
     }
 
     @Test
     public void testModeDoubleNan() {
-        List<Comparable<?>> mode;
+        Frequency<Double> f = new Frequency<>();
+        List<Double> mode;
         f.addValue(Double.valueOf(Double.NaN));
         f.addValue(Double.valueOf(Double.NaN));
         f.addValue(Double.valueOf(Double.NaN));
@@ -427,17 +329,12 @@ public final class FrequencyTest {
         Assert.assertEquals(Double.valueOf(Double.NEGATIVE_INFINITY), mode.get(0));
         Assert.assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), mode.get(1));
         Assert.assertEquals(Double.valueOf(Double.NaN), mode.get(2));
-        try {
-            f.addValue(Float.valueOf(Float.NaN));
-            Assert.fail("Expected MathIllegalArgumentException");
-        } catch (MathIllegalArgumentException e) {
-            // expected
-        }
     }
 
     @Test
     public void testModeFloatNan() {
-        List<Comparable<?>> mode;
+        Frequency<Float> f = new Frequency<>();
+        List<Float> mode;
         f.addValue(Float.valueOf(Float.NaN));
         f.addValue(Float.valueOf(Float.NaN));
         f.addValue(Float.valueOf(Float.NaN));
@@ -452,12 +349,6 @@ public final class FrequencyTest {
         Assert.assertEquals(Float.valueOf(Float.NEGATIVE_INFINITY), mode.get(0));
         Assert.assertEquals(Float.valueOf(Float.POSITIVE_INFINITY), mode.get(1));
         Assert.assertEquals(Float.valueOf(Float.NaN), mode.get(2));
-        try {
-            f.addValue(Double.valueOf(Double.NaN));
-            Assert.fail("Expected MathIllegalArgumentException");
-        } catch (MathIllegalArgumentException e) {
-            // expected
-        }
     }
 
 }


### PR DESCRIPTION
This pull request adds generics to the Frequency class, that right now supports long/int/chars, boxing values to long.

By design the current implementation uses ClassCastException as a mechanism to check if the values passed (i.e. Comparable<?>) is accepted by the underlying TreeMap; when the exception is thrown then it assumes it was expected and either ignores, or uses values like 0.

With the changes in this pull request, this design changes, and a Frequency<T> type will be useful for keeping track of frequecy-related metrics for entries of type T only.

As another positive thing, we do not have to use SuppressWarnings annotations any longer.

On the flip side, it breaks binary compatibility, requiring probably a major release of [math]. Initial work was on MATH-1408, but given this change digresses a bit from the scope of the issue, I created MATH-1413 to record just this change.

Cheers
Bruno