### PR TITLE
MATH-1381 check when both critical values are equal

### DIFF
--- a/src/main/java/org/apache/commons/math4/stat/inference/BinomialTest.java
+++ b/src/main/java/org/apache/commons/math4/stat/inference/BinomialTest.java
@@ -135,7 +135,11 @@ public class BinomialTest {
                 double pHigh = distribution.probability(criticalValueHigh);
 
                 if (pLow == pHigh) {
-                    pTotal += 2 * pLow;
+                    if (criticalValueLow == criticalValueHigh) {
+                        pTotal += pLow;
+                    } else {
+                        pTotal += 2 * pLow;
+                    }
                     criticalValueLow++;
                     criticalValueHigh--;
                 } else if (pLow < pHigh) {


### PR DESCRIPTION
This adds an if check from [hipparchus](https://github.com/Hipparchus-Math/hipparchus/blob/ff26617bd14472fa84d70e8efe66c1177f952145/hipparchus-stat/src/main/java/org/hipparchus/stat/inference/BinomialTest.java#L131) that for the example given in MATH-1381, p-value will be 1.0, instead of > 1.0 (which is not valid for a p-value).

