### PR TITLE
MATH-1401: cover cases where successes is zero, and where successes and trials are equals

### DIFF
--- a/src/main/java/org/apache/commons/math4/stat/interval/ClopperPearsonInterval.java
+++ b/src/main/java/org/apache/commons/math4/stat/interval/ClopperPearsonInterval.java
@@ -37,7 +37,14 @@ public class ClopperPearsonInterval implements BinomialConfidenceInterval {
         double lowerBound = 0;
         double upperBound = 0;
 
-        if (numberOfSuccesses > 0) {
+        if (numberOfSuccesses == 0) {
+            final double alpha = 1 - confidenceLevel;
+            upperBound = 1.0d - Math.pow(alpha / 2, 1 / (double) numberOfTrials);
+        } else if (numberOfSuccesses == numberOfTrials) {
+            final double alpha = 1 - confidenceLevel;
+            lowerBound = Math.pow(alpha / 2, 1 / (double) numberOfTrials);
+            upperBound = 1.0;
+        } else {
             final double alpha = 0.5 * (1 - confidenceLevel);
 
             final FDistribution distributionLowerBound = new FDistribution(2 * (numberOfTrials - numberOfSuccesses + 1),

--- a/src/test/java/org/apache/commons/math4/stat/interval/ClopperPearsonIntervalTest.java
+++ b/src/test/java/org/apache/commons/math4/stat/interval/ClopperPearsonIntervalTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.stat.interval;
 
+import static org.junit.Assert.assertEquals;
+
 import org.apache.commons.math4.stat.interval.BinomialConfidenceInterval;
 import org.apache.commons.math4.stat.interval.ClopperPearsonInterval;
 import org.apache.commons.math4.stat.interval.ConfidenceInterval;
@@ -40,4 +42,27 @@ public class ClopperPearsonIntervalTest extends BinomialConfidenceIntervalAbstra
         Assert.assertEquals(0.1248658, confidenceInterval.getUpperBound(), 1E-5);
     }
 
+    /*
+     * See MATH-1401 for more. Handles special cases for ClopperPearson, when the number
+     * of successes is zero, and when the number of successes and number of trials are
+     * equals.
+     */
+
+    @Test
+    public void testNumberOfSuccessesIsZero() {
+        ConfidenceInterval ci = testStatistic.createInterval(1, 0, 0.95);
+        ConfidenceInterval expected = new ConfidenceInterval(0.0, 0.975, ci.getConfidenceLevel());
+        //assertEquals(expected, ci); // TBD: ConfidenceInterval does not contain an equal method yet
+        assertEquals(expected.getLowerBound(), ci.getLowerBound(), 0.0d);
+        assertEquals(expected.getUpperBound(), ci.getUpperBound(), 0.0d);
+    }
+
+    @Test
+    public void testNumberOfSuccessesAndNumberOfTrialsAreEquals() {
+        ConfidenceInterval ci = testStatistic.createInterval(1, 1, 0.95);
+        ConfidenceInterval expected = new ConfidenceInterval(0.025, 1.0, ci.getConfidenceLevel());
+        //assertEquals(expected, ci); // TBD: ConfidenceInterval does not contain an equal method yet
+        assertEquals(expected.getLowerBound(), ci.getLowerBound(), 0.0001d);
+        assertEquals(expected.getUpperBound(), ci.getUpperBound(), 0.0d);
+    }
 }


### PR DESCRIPTION
See the JIRA ticket for complete investigation notes, links, and line of thought https://issues.apache.org/jira/browse/MATH-1401

Simply adds the proper if/else to check special cases where number of successes = 0, and where number of successes = number of trials. Unit tests added too, values matching output values from R PropCIs library.

Code was in sync with master before change, all tests passed, no issues found when generating website (skipping Javadoc; Java 8...). Checkstyle, PMD, and FindBugs all OK.

Cheers
Bruno