### PR TITLE
(doc) Fix throw desc for sampling funcs

### DIFF
--- a/src/main/java/org/apache/commons/math4/analysis/FunctionUtils.java
+++ b/src/main/java/org/apache/commons/math4/analysis/FunctionUtils.java
@@ -317,7 +317,7 @@ public class FunctionUtils {
      * @throws NumberIsTooLargeException if the lower bound {@code min} is
      * greater than, or equal to the upper bound {@code max}.
      * @throws NotStrictlyPositiveException if the number of sample points
-     * {@code n} is negative.
+     * {@code n} is not positive.
      */
     public static double[] sample(UnivariateFunction f, double min, double max, int n)
        throws NumberIsTooLargeException, NotStrictlyPositiveException {


### PR DESCRIPTION
`NotStrictlyPositiveException` is for non-positive numbers, i.e., negatives together with 0. But current Javadoc for sampling functions describes it for only negatives. To include 0 also, change **negative** to **not positive**.