### PR TITLE
Added empty relativePath element to parent in pox.xml in order to avoid Maven warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-parent</artifactId>
     <version>55</version>
+    <relativePath></relativePath>
   </parent>
 
   <artifactId>commons-math-parent</artifactId>


### PR DESCRIPTION
Added empty relativePath element to parent in pox.xml in order to avoid Maven warning.

This avoids warnings in the form of

```
Some problems were encountered while building the effective model for org.apache.commons:commons-math4:jar:4.0-SNAPSHOT
'parent.relativePath' of POM org.apache.commons:commons-math4:4.0-SNAPSHOT ([path to]/commons-math/pom.xml) points at [aggregator] instead of org.apache.commons:commons-parent, please verify your project structure @ line 19, column 11

It is highly recommended to fix these problems because they threaten the stability of your build.

For this reason, future Maven versions might no longer support building such malformed projects.
```

if the project is used in an aggregator Maven project and has no downside.