### PR TITLE
Feature: Support for larger sparse matrices

### DIFF
--- a/src/main/java/org/apache/commons/math4/linear/OpenMapBigRealMatrix.java
+++ b/src/main/java/org/apache/commons/math4/linear/OpenMapBigRealMatrix.java
@@ -1,0 +1,325 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.math4.linear;
+
+import org.apache.commons.math4.exception.DimensionMismatchException;
+import org.apache.commons.math4.exception.NotStrictlyPositiveException;
+import org.apache.commons.math4.exception.NumberIsTooLargeException;
+import org.apache.commons.math4.exception.OutOfRangeException;
+import org.apache.commons.math4.util.OpenIntToDoubleHashMap;
+import org.apache.commons.math4.util.OpenLongToDoubleHashMap;
+
+import java.io.Serializable;
+
+/**
+ * Sparse matrix implementation based on an open addressed map.
+ *
+ * <p>
+ *  Caveat: This implementation assumes that, for any {@code x},
+ *  the equality {@code x * 0d == 0d} holds. But it is is not true for
+ *  {@code NaN}. Moreover, zero entries will lose their sign.
+ *  Some operations (that involve {@code NaN} and/or infinities) may
+ *  thus give incorrect results.
+ * </p>
+ * @since 2.0
+ */
+public class OpenMapBigRealMatrix extends AbstractRealMatrix
+    implements SparseRealMatrix, Serializable {
+    /** Serializable version identifier. */
+    private static final long serialVersionUID = -5962461716457143437L;
+    /** Number of rows of the matrix. */
+    private final int rows;
+    /** Number of columns of the matrix. */
+    private final int columns;
+    /** Storage for (sparse) matrix elements. */
+    private final OpenLongToDoubleHashMap entries;
+
+    /**
+     * Build a sparse matrix with the supplied row and column dimensions.
+     *
+     * @param rowDimension Number of rows of the matrix.
+     * @param columnDimension Number of columns of the matrix.
+     * @throws NotStrictlyPositiveException if row or column dimension is not
+     * positive.
+     * @throws NumberIsTooLargeException if the total number of entries of the
+     * matrix is larger than {@code Integer.MAX_VALUE}.
+     */
+    public OpenMapBigRealMatrix(int rowDimension, int columnDimension)
+        throws NotStrictlyPositiveException, NumberIsTooLargeException {
+        super(rowDimension, columnDimension);
+        long lRow = rowDimension;
+        long lCol = columnDimension;
+        if (lRow * lCol >= Integer.MAX_VALUE) {
+            // not doing this is the hope point
+            //throw new NumberIsTooLargeException(lRow * lCol, Integer.MAX_VALUE, false);
+        }
+        this.rows = rowDimension;
+        this.columns = columnDimension;
+        this.entries = new OpenLongToDoubleHashMap(0.0);
+    }
+
+    /**
+     * Build a matrix by copying another one.
+     *
+     * @param matrix matrix to copy.
+     */
+    public OpenMapBigRealMatrix(OpenMapBigRealMatrix matrix) {
+        this.rows = matrix.rows;
+        this.columns = matrix.columns;
+        this.entries = new OpenLongToDoubleHashMap(matrix.entries);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public OpenMapBigRealMatrix copy() {
+        return new OpenMapBigRealMatrix(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NumberIsTooLargeException if the total number of entries of the
+     * matrix is larger than {@code Integer.MAX_VALUE}.
+     */
+    @Override
+    public OpenMapBigRealMatrix createMatrix(int rowDimension, int columnDimension)
+        throws NotStrictlyPositiveException, NumberIsTooLargeException {
+        return new OpenMapBigRealMatrix(rowDimension, columnDimension);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getColumnDimension() {
+        return columns;
+    }
+
+    /**
+     * Compute the sum of this matrix and {@code m}.
+     *
+     * @param m Matrix to be added.
+     * @return {@code this} + {@code m}.
+     * @throws MatrixDimensionMismatchException if {@code m} is not the same
+     * size as {@code this}.
+     */
+    public OpenMapBigRealMatrix add(OpenMapBigRealMatrix m)
+        throws MatrixDimensionMismatchException {
+
+        MatrixUtils.checkAdditionCompatible(this, m);
+
+        final OpenMapBigRealMatrix out = new OpenMapBigRealMatrix(this);
+        for (OpenLongToDoubleHashMap.Iterator iterator = m.entries.iterator(); iterator.hasNext();) {
+            iterator.advance();
+            final int row = (int) (iterator.key() / columns);
+            final int col = (int) (iterator.key() - row * columns);
+            out.setEntry(row, col, getEntry(row, col) + iterator.value());
+        }
+
+        return out;
+
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public OpenMapBigRealMatrix subtract(final RealMatrix m)
+        throws MatrixDimensionMismatchException {
+        try {
+            return subtract((OpenMapBigRealMatrix) m);
+        } catch (ClassCastException cce) {
+            return (OpenMapBigRealMatrix) super.subtract(m);
+        }
+    }
+
+    /**
+     * Subtract {@code m} from this matrix.
+     *
+     * @param m Matrix to be subtracted.
+     * @return {@code this} - {@code m}.
+     * @throws MatrixDimensionMismatchException if {@code m} is not the same
+     * size as {@code this}.
+     */
+    public OpenMapBigRealMatrix subtract(OpenMapBigRealMatrix m)
+        throws MatrixDimensionMismatchException {
+        MatrixUtils.checkAdditionCompatible(this, m);
+
+        final OpenMapBigRealMatrix out = new OpenMapBigRealMatrix(this);
+        for (OpenLongToDoubleHashMap.Iterator iterator = m.entries.iterator(); iterator.hasNext();) {
+            iterator.advance();
+            final int row = (int) (iterator.key() / columns);
+            final int col = (int) (iterator.key() - row * columns);
+            out.setEntry(row, col, getEntry(row, col) - iterator.value());
+        }
+
+        return out;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws NumberIsTooLargeException if {@code m} is an
+     * {@code OpenMapRealMatrix}, and the total number of entries of the product
+     * is larger than {@code Integer.MAX_VALUE}.
+     */
+    @Override
+    public RealMatrix multiply(final RealMatrix m)
+        throws DimensionMismatchException, NumberIsTooLargeException {
+        try {
+            return multiply((OpenMapBigRealMatrix) m);
+        } catch (ClassCastException cce) {
+
+            MatrixUtils.checkMultiplicationCompatible(this, m);
+
+            final int outCols = m.getColumnDimension();
+            final BlockRealMatrix out = new BlockRealMatrix(rows, outCols);
+            for (OpenLongToDoubleHashMap.Iterator iterator = entries.iterator(); iterator.hasNext();) {
+                iterator.advance();
+                final double value = iterator.value();
+                final long key      = iterator.key();
+                final int i        = (int) (key / columns);
+                final int k        = (int) (key % columns);
+                for (int j = 0; j < outCols; ++j) {
+                    out.addToEntry(i, j, value * m.getEntry(k, j));
+                }
+            }
+
+            return out;
+        }
+    }
+
+    /**
+     * Postmultiply this matrix by {@code m}.
+     *
+     * @param m Matrix to postmultiply by.
+     * @return {@code this} * {@code m}.
+     * @throws DimensionMismatchException if the number of rows of {@code m}
+     * differ from the number of columns of {@code this} matrix.
+     * @throws NumberIsTooLargeException if the total number of entries of the
+     * product is larger than {@code Integer.MAX_VALUE}.
+     */
+    public OpenMapBigRealMatrix multiply(OpenMapBigRealMatrix m)
+        throws DimensionMismatchException, NumberIsTooLargeException {
+        // Safety check.
+        MatrixUtils.checkMultiplicationCompatible(this, m);
+
+        final int outCols = m.getColumnDimension();
+        OpenMapBigRealMatrix out = new OpenMapBigRealMatrix(rows, outCols);
+        for (OpenLongToDoubleHashMap.Iterator iterator = entries.iterator(); iterator.hasNext();) {
+            iterator.advance();
+            final double value = iterator.value();
+            final long key      = iterator.key();
+            final int i        = (int) (key / columns);
+            final int k        = (int) (key % columns);
+            for (int j = 0; j < outCols; ++j) {
+                final long rightKey = m.computeKey(k, j);
+                if (m.entries.containsKey(rightKey)) {
+                    final long outKey = out.computeKey(i, j);
+                    final double outValue =
+                        out.entries.get(outKey) + value * m.entries.get(rightKey);
+                    if (outValue == 0.0) {
+                        out.entries.remove(outKey);
+                    } else {
+                        out.entries.put(outKey, outValue);
+                    }
+                }
+            }
+        }
+
+        return out;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public double getEntry(int row, int column) throws OutOfRangeException {
+        if(row<0||row>=getRowDimension()) {
+            throw new OutOfRangeException(row,0,getRowDimension());
+
+        } else if(column<0||column>=getColumnDimension()) {
+            throw new OutOfRangeException(column,0,getColumnDimension());
+        }
+        MatrixUtils.checkRowIndex(this, row);
+        MatrixUtils.checkColumnIndex(this, column);
+        return entries.get(computeKey(row, column));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getRowDimension() {
+        return rows;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setEntry(int row, int column, double value)
+        throws OutOfRangeException {
+        MatrixUtils.checkRowIndex(this, row);
+        MatrixUtils.checkColumnIndex(this, column);
+        if (value == 0.0) {
+            entries.remove(computeKey(row, column));
+        } else {
+            entries.put(computeKey(row, column), value);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void addToEntry(int row, int column, double increment)
+        throws OutOfRangeException {
+        MatrixUtils.checkRowIndex(this, row);
+        MatrixUtils.checkColumnIndex(this, column);
+        final long key = computeKey(row, column);
+        final double value = entries.get(key) + increment;
+        if (value == 0.0) {
+            entries.remove(key);
+        } else {
+            entries.put(key, value);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void multiplyEntry(int row, int column, double factor)
+        throws OutOfRangeException {
+        MatrixUtils.checkRowIndex(this, row);
+        MatrixUtils.checkColumnIndex(this, column);
+        final long key = computeKey(row, column);
+        final double value = entries.get(key) * factor;
+        if (value == 0.0) {
+            entries.remove(key);
+        } else {
+            entries.put(key, value);
+        }
+    }
+
+    /**
+     * Compute the key to access a matrix element
+     * @param row row index of the matrix element
+     * @param column column index of the matrix element
+     * @return key within the map to access the matrix element
+     */
+    private long computeKey(int row, int column) {
+        return row * columns + column;
+    }
+
+
+    public static void main(String[] args) {
+        OpenMapBigRealMatrix matrix = new OpenMapBigRealMatrix(60000,60000);
+        matrix.addToEntry(235,2362,203956);
+        System.out.println(matrix.getEntry(235,2362));
+        System.out.println(matrix.getEntry(0,2362));
+
+    }
+}

--- a/src/main/java/org/apache/commons/math4/util/OpenLongToDoubleHashMap.java
+++ b/src/main/java/org/apache/commons/math4/util/OpenLongToDoubleHashMap.java
@@ -1,0 +1,596 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.math4.util;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.ConcurrentModificationException;
+import java.util.NoSuchElementException;
+
+/**
+ * Open addressed map from int to double.
+ * <p>This class provides a dedicated map from integers to doubles with a
+ * much smaller memory overhead than standard <code>java.util.Map</code>.</p>
+ * <p>This class is not synchronized. The specialized iterators returned by
+ * {@link #iterator()} are fail-fast: they throw a
+ * <code>ConcurrentModificationException</code> when they detect the map has been
+ * modified during iteration.</p>
+ * @since 2.0
+ */
+public class OpenLongToDoubleHashMap implements Serializable {
+
+    /** Status indicator for free table entries. */
+    protected static final byte FREE    = 0;
+
+    /** Status indicator for full table entries. */
+    protected static final byte FULL    = 1;
+
+    /** Status indicator for removed table entries. */
+    protected static final byte REMOVED = 2;
+
+    /** Serializable version identifier */
+    private static final long serialVersionUID = -3646337053166149105L;
+
+    /** Load factor for the map. */
+    private static final float LOAD_FACTOR = 0.5f;
+
+    /** Default starting size.
+     * <p>This must be a power of two for bit mask to work properly. </p>
+     */
+    private static final int DEFAULT_EXPECTED_SIZE = 16;
+
+    /** Multiplier for size growth when map fills up.
+     * <p>This must be a power of two for bit mask to work properly. </p>
+     */
+    private static final int RESIZE_MULTIPLIER = 2;
+
+    /** Number of bits to perturb the index when probing for collision resolution. */
+    private static final int PERTURB_SHIFT = 5;
+
+    /** Keys table. */
+    private long[] keys;
+
+    /** Values table. */
+    private double[] values;
+
+    /** States table. */
+    private byte[] states;
+
+    /** Return value for missing entries. */
+    private final double missingEntries;
+
+    /** Current size of the map. */
+    private int size;
+
+    /** Bit mask for hash values. */
+    private int mask;
+
+    /** Modifications count. */
+    private transient int count;
+
+    /**
+     * Build an empty map with default size and using NaN for missing entries.
+     */
+    public OpenLongToDoubleHashMap() {
+        this(DEFAULT_EXPECTED_SIZE, Double.NaN);
+    }
+
+    /**
+     * Build an empty map with default size
+     * @param missingEntries value to return when a missing entry is fetched
+     */
+    public OpenLongToDoubleHashMap(final double missingEntries) {
+        this(DEFAULT_EXPECTED_SIZE, missingEntries);
+    }
+
+    /**
+     * Build an empty map with specified size and using NaN for missing entries.
+     * @param expectedSize expected number of elements in the map
+     */
+    public OpenLongToDoubleHashMap(final int expectedSize) {
+        this(expectedSize, Double.NaN);
+    }
+
+    /**
+     * Build an empty map with specified size.
+     * @param expectedSize expected number of elements in the map
+     * @param missingEntries value to return when a missing entry is fetched
+     */
+    public OpenLongToDoubleHashMap(final int expectedSize,
+                                   final double missingEntries) {
+        final int capacity = computeCapacity(expectedSize);
+        keys   = new long[capacity];
+        values = new double[capacity];
+        states = new byte[capacity];
+        this.missingEntries = missingEntries;
+        mask   = capacity - 1;
+    }
+
+    /**
+     * Copy constructor.
+     * @param source map to copy
+     */
+    public OpenLongToDoubleHashMap(final OpenLongToDoubleHashMap source) {
+        final int length = source.keys.length;
+        keys = new long[length];
+        System.arraycopy(source.keys, 0, keys, 0, length);
+        values = new double[length];
+        System.arraycopy(source.values, 0, values, 0, length);
+        states = new byte[length];
+        System.arraycopy(source.states, 0, states, 0, length);
+        missingEntries = source.missingEntries;
+        size  = source.size;
+        mask  = source.mask;
+        count = source.count;
+    }
+
+    /**
+     * Compute the capacity needed for a given size.
+     * @param expectedSize expected size of the map
+     * @return capacity to use for the specified size
+     */
+    private static int computeCapacity(final int expectedSize) {
+        if (expectedSize == 0) {
+            return 1;
+        }
+        final int capacity   = (int) FastMath.ceil(expectedSize / LOAD_FACTOR);
+        final int powerOfTwo = Integer.highestOneBit(capacity);
+        if (powerOfTwo == capacity) {
+            return capacity;
+        }
+        return nextPowerOfTwo(capacity);
+    }
+
+    /**
+     * Find the smallest power of two greater than the input value
+     * @param i input value
+     * @return smallest power of two greater than the input value
+     */
+    private static int nextPowerOfTwo(final int i) {
+        return Integer.highestOneBit(i) << 1;
+    }
+
+    /**
+     * Get the stored value associated with the given key
+     * @param key key associated with the data
+     * @return data associated with the key
+     */
+    public double get(final long key) {
+
+        final int hash  = hashOf(key);
+        int index = (int) (hash & mask);
+        if (containsKey(key, index)) {
+            return values[index];
+        }
+
+        if (states[index] == FREE) {
+            return missingEntries;
+        }
+
+        int j = index;
+        for (int perturb = perturb(hash); states[index] != FREE; perturb >>= PERTURB_SHIFT) {
+            j = probe(perturb, j);
+            index = j & mask;
+            if (containsKey(key, index)) {
+                return values[index];
+            }
+        }
+
+        return missingEntries;
+
+    }
+
+    /**
+     * Check if a value is associated with a key.
+     * @param key key to check
+     * @return true if a value is associated with key
+     */
+    public boolean containsKey(final long key) {
+
+        final int hash  = hashOf(key);
+        int index = (hash & mask);
+        if (containsKey(key, index)) {
+            return true;
+        }
+
+        if (states[index] == FREE) {
+            return false;
+        }
+
+        int j = index;
+        for (int perturb = perturb(hash); states[index] != FREE; perturb >>= PERTURB_SHIFT) {
+            j = probe(perturb, j);
+            index = j & mask;
+            if (containsKey(key, index)) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }
+
+    /**
+     * Get an iterator over map elements.
+     * <p>The specialized iterators returned are fail-fast: they throw a
+     * <code>ConcurrentModificationException</code> when they detect the map
+     * has been modified during iteration.</p>
+     * @return iterator over the map elements
+     */
+    public Iterator iterator() {
+        return new Iterator();
+    }
+
+    /**
+     * Perturb the hash for starting probing.
+     * @param hash initial hash
+     * @return perturbed hash
+     */
+    private static int perturb(final int hash) {
+        return hash & 0x7fffffff;
+    }
+
+    /**
+     * Find the index at which a key should be inserted
+     * @param key key to lookup
+     * @return index at which key should be inserted
+     */
+    private int findInsertionIndex(final long key) {
+        return findInsertionIndex(keys, states, key, mask);
+    }
+
+    /**
+     * Find the index at which a key should be inserted
+     * @param keys keys table
+     * @param states states table
+     * @param key key to lookup
+     * @param mask bit mask for hash values
+     * @return index at which key should be inserted
+     */
+    private static int findInsertionIndex(final long[] keys, final byte[] states,
+                                          final long key, final int mask) {
+        final int hash = hashOf(key);
+        int index = hash & mask;
+        if (states[index] == FREE) {
+            return index;
+        } else if (states[index] == FULL && keys[index] == key) {
+            return changeIndexSign(index);
+        }
+
+        int perturb = perturb(hash);
+        int j = index;
+        if (states[index] == FULL) {
+            while (true) {
+                j = probe(perturb, j);
+                index = j & mask;
+                perturb >>= PERTURB_SHIFT;
+
+                if (states[index] != FULL || keys[index] == key) {
+                    break;
+                }
+            }
+        }
+
+        if (states[index] == FREE) {
+            return index;
+        } else if (states[index] == FULL) {
+            // due to the loop exit condition,
+            // if (states[index] == FULL) then keys[index] == key
+            return changeIndexSign(index);
+        }
+
+        final int firstRemoved = index;
+        while (true) {
+            j = probe(perturb, j);
+            index = j & mask;
+
+            if (states[index] == FREE) {
+                return firstRemoved;
+            } else if (states[index] == FULL && keys[index] == key) {
+                return changeIndexSign(index);
+            }
+
+            perturb >>= PERTURB_SHIFT;
+
+        }
+
+    }
+
+    /**
+     * Compute next probe for collision resolution
+     * @param perturb perturbed hash
+     * @param j previous probe
+     * @return next probe
+     */
+    private static int probe(final int perturb, final int j) {
+        return (j << 2) + j + perturb + 1;
+    }
+
+    /**
+     * Change the index sign
+     * @param index initial index
+     * @return changed index
+     */
+    private static int changeIndexSign(final int index) {
+        return -index - 1;
+    }
+
+    /**
+     * Get the number of elements stored in the map.
+     * @return number of elements stored in the map
+     */
+    public int size() {
+        return size;
+    }
+
+
+    /**
+     * Remove the value associated with a key.
+     * @param key key to which the value is associated
+     * @return removed value
+     */
+    public double remove(final long key) {
+
+        final int hash  = hashOf(key);
+        int index =  hash & mask;
+        if (containsKey(key, index)) {
+            return doRemove(index);
+        }
+
+        if (states[index] == FREE) {
+            return missingEntries;
+        }
+
+        int j = index;
+        for (int perturb = perturb(hash); states[index] != FREE; perturb >>= PERTURB_SHIFT) {
+            j = probe(perturb, j);
+            index = j & mask;
+            if (containsKey(key, index)) {
+                return doRemove(index);
+            }
+        }
+
+        return missingEntries;
+
+    }
+
+    /**
+     * Check if the tables contain an element associated with specified key
+     * at specified index.
+     * @param key key to check
+     * @param index index to check
+     * @return true if an element is associated with key at index
+     */
+    private boolean containsKey(final long key, final int index) {
+        return (key != 0 || states[index] == FULL) && keys[index] == key;
+    }
+
+    /**
+     * Remove an element at specified index.
+     * @param index index of the element to remove
+     * @return removed value
+     */
+    private double doRemove(int index) {
+        keys[index]   = 0;
+        states[index] = REMOVED;
+        final double previous = values[index];
+        values[index] = missingEntries;
+        --size;
+        ++count;
+        return previous;
+    }
+
+    /**
+     * Put a value associated with a key in the map.
+     * @param key key to which value is associated
+     * @param value value to put in the map
+     * @return previous value associated with the key
+     */
+    public double put(final long key, final double value) {
+        int index = findInsertionIndex(key);
+        double previous = missingEntries;
+        boolean newMapping = true;
+        if (index < 0) {
+            index = changeIndexSign(index);
+            previous = values[index];
+            newMapping = false;
+        }
+        keys[index]   = key;
+        states[index] = FULL;
+        values[index] = value;
+        if (newMapping) {
+            ++size;
+            if (shouldGrowTable()) {
+                growTable();
+            }
+            ++count;
+        }
+        return previous;
+
+    }
+
+    /**
+     * Grow the tables.
+     */
+    private void growTable() {
+
+        final int oldLength      = states.length;
+        final long[] oldKeys      = keys;
+        final double[] oldValues = values;
+        final byte[] oldStates   = states;
+
+        final int newLength = RESIZE_MULTIPLIER * oldLength;
+        final long[] newKeys = new long[newLength];
+        final double[] newValues = new double[newLength];
+        final byte[] newStates = new byte[newLength];
+        final int newMask = newLength - 1;
+        for (int i = 0; i < oldLength; ++i) {
+            if (oldStates[i] == FULL) {
+                final long key = oldKeys[i];
+                final int index = findInsertionIndex(newKeys, newStates, key, newMask);
+                newKeys[index]   = key;
+                newValues[index] = oldValues[i];
+                newStates[index] = FULL;
+            }
+        }
+
+        mask   = newMask;
+        keys   = newKeys;
+        values = newValues;
+        states = newStates;
+
+    }
+
+    /**
+     * Check if tables should grow due to increased size.
+     * @return true if  tables should grow
+     */
+    private boolean shouldGrowTable() {
+        return size > (mask + 1) * LOAD_FACTOR;
+    }
+
+    /**
+     * Compute the hash value of a key
+     * @param key key to hash
+     * @return hash value of the key
+     */
+    private static int hashOf(final long key) {
+        final long h = key ^ ((key >>> 20) ^ (key >>> 12));
+        return (int)(h ^ (h >>> 7) ^ (h >>> 4));
+    }
+
+
+    /** Iterator class for the map. */
+    public class Iterator {
+
+        /** Reference modification count. */
+        private final int referenceCount;
+
+        /** Index of current element. */
+        private int current;
+
+        /** Index of next element. */
+        private int next;
+
+        /**
+         * Simple constructor.
+         */
+        private Iterator() {
+
+            // preserve the modification count of the map to detect concurrent modifications later
+            referenceCount = count;
+
+            // initialize current index
+            next = -1;
+            try {
+                advance();
+            } catch (NoSuchElementException nsee) { // NOPMD
+                // ignored
+            }
+
+        }
+
+        /**
+         * Check if there is a next element in the map.
+         * @return true if there is a next element
+         */
+        public boolean hasNext() {
+            return next >= 0;
+        }
+
+        /**
+         * Get the key of current entry.
+         * @return key of current entry
+         * @exception ConcurrentModificationException if the map is modified during iteration
+         * @exception NoSuchElementException if there is no element left in the map
+         */
+        public long key()
+            throws ConcurrentModificationException, NoSuchElementException {
+            if (referenceCount != count) {
+                throw new ConcurrentModificationException();
+            }
+            if (current < 0) {
+                throw new NoSuchElementException();
+            }
+            return keys[current];
+        }
+
+        /**
+         * Get the value of current entry.
+         * @return value of current entry
+         * @exception ConcurrentModificationException if the map is modified during iteration
+         * @exception NoSuchElementException if there is no element left in the map
+         */
+        public double value()
+            throws ConcurrentModificationException, NoSuchElementException {
+            if (referenceCount != count) {
+                throw new ConcurrentModificationException();
+            }
+            if (current < 0) {
+                throw new NoSuchElementException();
+            }
+            return values[current];
+        }
+
+        /**
+         * Advance iterator one step further.
+         * @exception ConcurrentModificationException if the map is modified during iteration
+         * @exception NoSuchElementException if there is no element left in the map
+         */
+        public void advance()
+            throws ConcurrentModificationException, NoSuchElementException {
+
+            if (referenceCount != count) {
+                throw new ConcurrentModificationException();
+            }
+
+            // advance on step
+            current = next;
+
+            // prepare next step
+            try {
+                while (states[++next] != FULL) { // NOPMD
+                    // nothing to do
+                }
+            } catch (ArrayIndexOutOfBoundsException e) {
+                next = -2;
+                if (current < 0) {
+                    throw new NoSuchElementException();
+                }
+            }
+
+        }
+
+    }
+
+    /**
+     * Read a serialized object.
+     * @param stream input stream
+     * @throws IOException if object cannot be read
+     * @throws ClassNotFoundException if the class corresponding
+     * to the serialized object cannot be found
+     */
+    private void readObject(final ObjectInputStream stream)
+        throws IOException, ClassNotFoundException {
+        stream.defaultReadObject();
+        count = 0;
+    }
+
+
+}

--- a/src/test/java/org/apache/commons/math4/linear/OpenMapBigRealMatrixTest.java
+++ b/src/test/java/org/apache/commons/math4/linear/OpenMapBigRealMatrixTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.math4.linear;
+
+import org.apache.commons.math4.exception.NumberIsTooLargeException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public final class OpenMapBigRealMatrixTest {
+
+    @Test
+    public void testMath679() {
+        new OpenMapBigRealMatrix(3, Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testMath870() {
+        // Caveat: This implementation assumes that, for any {@code x},
+        // the equality {@code x * 0d == 0d} holds. But it is is not true for
+        // {@code NaN}. Moreover, zero entries will lose their sign.
+        // Some operations (that involve {@code NaN} and/or infinities) may
+        // thus give incorrect results.
+        OpenMapBigRealMatrix a = new OpenMapBigRealMatrix(3, 3);
+        OpenMapBigRealMatrix x = new OpenMapBigRealMatrix(3, 1);
+        x.setEntry(0, 0, Double.NaN);
+        x.setEntry(2, 0, Double.NEGATIVE_INFINITY);
+        OpenMapBigRealMatrix b = a.multiply(x);
+        for (int i = 0; i < b.getRowDimension(); ++i) {
+            for (int j = 0; j < b.getColumnDimension(); ++j) {
+                // NaNs and infinities have disappeared, this is a limitation of our implementation
+                Assert.assertEquals(0.0, b.getEntry(i, j), 1.0e-20);
+            }
+        }
+    }
+}

--- a/src/test/java/org/apache/commons/math4/util/OpenLongToDoubleHashMapTest.java
+++ b/src/test/java/org/apache/commons/math4/util/OpenLongToDoubleHashMapTest.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.math4.util;
+
+import org.apache.commons.numbers.core.Precision;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+
+
+/**
+ * Test cases for the {@link OpenIntToDoubleHashMap}.
+ */
+@SuppressWarnings("boxing")
+public class OpenLongToDoubleHashMapTest {
+
+    private Map<Long, Double> javaMap = new HashMap<>();
+
+    @Before
+    public void setUp() throws Exception {
+        javaMap.put(50L, 100.0);
+        javaMap.put(75L, 75.0);
+        javaMap.put(25L, 500.0);
+        javaMap.put((long)Integer.MAX_VALUE, Double.MAX_VALUE);
+        javaMap.put(0L, -1.0);
+        javaMap.put(1L, 0.0);
+        javaMap.put(33L, -0.1);
+        javaMap.put(23234234L, -242343.0);
+        javaMap.put(23321L, Double.MIN_VALUE);
+        javaMap.put(-4444L, 332.0);
+        javaMap.put(-1L, -2323.0);
+        javaMap.put((long)Integer.MIN_VALUE, 44.0);
+
+        /* Add a few more to cause the table to rehash */
+        javaMap.putAll(generate());
+
+    }
+
+    private Map<Long, Double> generate() {
+        Map<Long, Double> map = new HashMap<>();
+        Random r = new Random();
+        for (int i = 0; i < 2000; ++i) {
+            map.put(r.nextLong(), r.nextDouble());
+        }
+        return map;
+    }
+
+    private OpenLongToDoubleHashMap createFromJavaMap() {
+        OpenLongToDoubleHashMap map = new OpenLongToDoubleHashMap();
+        for (Map.Entry<Long, Double> mapEntry : javaMap.entrySet()) {
+            map.put(mapEntry.getKey(), mapEntry.getValue());
+        }
+        return map;
+    }
+
+    @Test
+    public void testPutAndGetWith0ExpectedSize() {
+        OpenLongToDoubleHashMap map = new OpenLongToDoubleHashMap(0);
+        assertPutAndGet(map);
+    }
+
+    @Test
+    public void testPutAndGetWithExpectedSize() {
+        OpenLongToDoubleHashMap map = new OpenLongToDoubleHashMap(500);
+        assertPutAndGet(map);
+    }
+
+    @Test
+    public void testPutAndGet() {
+        OpenLongToDoubleHashMap map = new OpenLongToDoubleHashMap();
+        assertPutAndGet(map);
+    }
+
+    private void assertPutAndGet(OpenLongToDoubleHashMap map) {
+        assertPutAndGet(map, 0, new HashSet<Long>());
+    }
+
+    private void assertPutAndGet(OpenLongToDoubleHashMap map, int mapSize,
+            Set<Long> keysInMap) {
+        Assert.assertEquals(mapSize, map.size());
+        for (Map.Entry<Long, Double> mapEntry : javaMap.entrySet()) {
+            map.put(mapEntry.getKey(), mapEntry.getValue());
+            if (!keysInMap.contains(mapEntry.getKey())) {
+                ++mapSize;
+            }
+            Assert.assertEquals(mapSize, map.size());
+            Assert.assertTrue(Precision.equals(mapEntry.getValue(), map.get(mapEntry.getKey()), 1));
+        }
+    }
+
+    @Test
+    public void testPutAbsentOnExisting() {
+        OpenLongToDoubleHashMap map = createFromJavaMap();
+        int size = javaMap.size();
+        for (Map.Entry<Long, Double> mapEntry : generateAbsent().entrySet()) {
+            map.put(mapEntry.getKey(), mapEntry.getValue());
+            Assert.assertEquals(++size, map.size());
+            Assert.assertTrue(Precision.equals(mapEntry.getValue(), map.get(mapEntry.getKey()), 1));
+        }
+    }
+
+    @Test
+    public void testPutOnExisting() {
+        OpenLongToDoubleHashMap map = createFromJavaMap();
+        for (Map.Entry<Long, Double> mapEntry : javaMap.entrySet()) {
+            map.put(mapEntry.getKey(), mapEntry.getValue());
+            Assert.assertEquals(javaMap.size(), map.size());
+            Assert.assertTrue(Precision.equals(mapEntry.getValue(), map.get(mapEntry.getKey()), 1));
+        }
+    }
+
+    @Test
+    public void testGetAbsent() {
+        Map<Long, Double> generated = generateAbsent();
+        OpenLongToDoubleHashMap map = createFromJavaMap();
+
+        for (Map.Entry<Long, Double> mapEntry : generated.entrySet()) {
+            Assert.assertTrue(Double.isNaN(map.get(mapEntry.getKey())));
+        }
+    }
+
+    @Test
+    public void testGetFromEmpty() {
+        OpenLongToDoubleHashMap map = new OpenLongToDoubleHashMap();
+        Assert.assertTrue(Double.isNaN(map.get(5)));
+        Assert.assertTrue(Double.isNaN(map.get(0)));
+        Assert.assertTrue(Double.isNaN(map.get(50)));
+    }
+
+    @Test
+    public void testRemove() {
+        OpenLongToDoubleHashMap map = createFromJavaMap();
+        int mapSize = javaMap.size();
+        Assert.assertEquals(mapSize, map.size());
+        for (Map.Entry<Long, Double> mapEntry : javaMap.entrySet()) {
+            map.remove(mapEntry.getKey());
+            Assert.assertEquals(--mapSize, map.size());
+            Assert.assertTrue(Double.isNaN(map.get(mapEntry.getKey())));
+        }
+
+        /* Ensure that put and get still work correctly after removals */
+        assertPutAndGet(map);
+    }
+
+    /* This time only remove some entries */
+    @Test
+    public void testRemove2() {
+        OpenLongToDoubleHashMap map = createFromJavaMap();
+        int mapSize = javaMap.size();
+        int count = 0;
+        Set<Long> keysInMap = new HashSet<>(javaMap.keySet());
+        for (Map.Entry<Long, Double> mapEntry : javaMap.entrySet()) {
+            keysInMap.remove(mapEntry.getKey());
+            map.remove(mapEntry.getKey());
+            Assert.assertEquals(--mapSize, map.size());
+            Assert.assertTrue(Double.isNaN(map.get(mapEntry.getKey())));
+            if (count++ > 5) {
+                break;
+            }
+        }
+
+        /* Ensure that put and get still work correctly after removals */
+        assertPutAndGet(map, mapSize, keysInMap);
+    }
+
+    @Test
+    public void testRemoveFromEmpty() {
+        OpenIntToDoubleHashMap map = new OpenIntToDoubleHashMap();
+        Assert.assertTrue(Double.isNaN(map.remove(50)));
+    }
+
+    @Test
+    public void testRemoveAbsent() {
+        Map<Long, Double> generated = generateAbsent();
+
+        OpenLongToDoubleHashMap map = createFromJavaMap();
+        int mapSize = map.size();
+
+        for (Map.Entry<Long, Double> mapEntry : generated.entrySet()) {
+            map.remove(mapEntry.getKey());
+            Assert.assertEquals(mapSize, map.size());
+            Assert.assertTrue(Double.isNaN(map.get(mapEntry.getKey())));
+        }
+    }
+
+    /**
+     * Returns a map with at least 100 elements where each element is absent from javaMap.
+     */
+    private Map<Long, Double> generateAbsent() {
+        Map<Long, Double> generated = new HashMap<>();
+        do {
+            generated.putAll(generate());
+            for (Long key : javaMap.keySet()) {
+                generated.remove(key);
+            }
+        } while (generated.size() < 100);
+        return generated;
+    }
+
+    @Test
+    public void testCopy() {
+        OpenLongToDoubleHashMap copy =
+            new OpenLongToDoubleHashMap(createFromJavaMap());
+        Assert.assertEquals(javaMap.size(), copy.size());
+
+        for (Map.Entry<Long, Double> mapEntry : javaMap.entrySet()) {
+            Assert.assertTrue(Precision.equals(mapEntry.getValue(), copy.get(mapEntry.getKey()), 1));
+        }
+    }
+
+    @Test
+    public void testContainsKey() {
+        OpenLongToDoubleHashMap map = createFromJavaMap();
+        for (Map.Entry<Long, Double> mapEntry : javaMap.entrySet()) {
+            Assert.assertTrue(map.containsKey(mapEntry.getKey()));
+        }
+        for (Map.Entry<Long, Double> mapEntry : generateAbsent().entrySet()) {
+            Assert.assertFalse(map.containsKey(mapEntry.getKey()));
+        }
+        for (Map.Entry<Long, Double> mapEntry : javaMap.entrySet()) {
+            long key = mapEntry.getKey();
+            Assert.assertTrue(map.containsKey(key));
+            map.remove(key);
+            Assert.assertFalse(map.containsKey(key));
+        }
+    }
+
+    @Test
+    public void testIterator() {
+        OpenLongToDoubleHashMap map = createFromJavaMap();
+        OpenLongToDoubleHashMap.Iterator iterator = map.iterator();
+        for (int i = 0; i < map.size(); ++i) {
+            Assert.assertTrue(iterator.hasNext());
+            iterator.advance();
+            long key = iterator.key();
+            Assert.assertTrue(map.containsKey(key));
+            Assert.assertEquals(javaMap.get(key), map.get(key), 0);
+            Assert.assertEquals(javaMap.get(key), iterator.value(), 0);
+            Assert.assertTrue(javaMap.containsKey(key));
+        }
+        Assert.assertFalse(iterator.hasNext());
+        try {
+            iterator.advance();
+            Assert.fail("an exception should have been thrown");
+        } catch (NoSuchElementException nsee) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testConcurrentModification() {
+        OpenLongToDoubleHashMap map = createFromJavaMap();
+        OpenLongToDoubleHashMap.Iterator iterator = map.iterator();
+        map.put(3, 3);
+        try {
+            iterator.advance();
+            Assert.fail("an exception should have been thrown");
+        } catch (ConcurrentModificationException cme) {
+            // expected
+        }
+    }
+
+    /**
+     * Regression test for a bug in findInsertionIndex where the hashing in the second probing
+     * loop was inconsistent with the first causing duplicate keys after the right sequence
+     * of puts and removes.
+     */
+    @Test
+    public void testPutKeysWithCollisions() {
+        OpenIntToDoubleHashMap map = new OpenIntToDoubleHashMap();
+        int key1 = -1996012590;
+        double value1 = 1.0;
+        map.put(key1, value1);
+        int key2 = 835099822;
+        map.put(key2, value1);
+        int key3 = 1008859686;
+        map.put(key3, value1);
+        Assert.assertTrue(Precision.equals(value1, map.get(key3), 1));
+        Assert.assertEquals(3, map.size());
+
+        map.remove(key2);
+        double value2 = 2.0;
+        map.put(key3, value2);
+        Assert.assertTrue(Precision.equals(value2, map.get(key3), 1));
+        Assert.assertEquals(2, map.size());
+    }
+
+    /**
+     * Similar to testPutKeysWithCollisions() but exercises the codepaths in a slightly
+     * different manner.
+     */
+    @Test
+    public void testPutKeysWithCollision2() {
+        OpenIntToDoubleHashMap map = new OpenIntToDoubleHashMap();
+        int key1 = 837989881;
+        double value1 = 1.0;
+        map.put(key1, value1);
+        int key2 = 476463321;
+        map.put(key2, value1);
+        Assert.assertEquals(2, map.size());
+        Assert.assertTrue(Precision.equals(value1, map.get(key2), 1));
+
+        map.remove(key1);
+        double value2 = 2.0;
+        map.put(key2, value2);
+        Assert.assertEquals(1, map.size());
+        Assert.assertTrue(Precision.equals(value2, map.get(key2), 1));
+    }
+
+}

--- a/src/test/java/org/apache/commons/math4/util/OpenLongToDoubleHashMapTest.java
+++ b/src/test/java/org/apache/commons/math4/util/OpenLongToDoubleHashMapTest.java
@@ -25,7 +25,7 @@ import java.util.*;
 
 
 /**
- * Test cases for the {@link OpenIntToDoubleHashMap}.
+ * Test cases for the {@link OpenLongToDoubleHashMap}.
  */
 @SuppressWarnings("boxing")
 public class OpenLongToDoubleHashMapTest {
@@ -181,7 +181,7 @@ public class OpenLongToDoubleHashMapTest {
 
     @Test
     public void testRemoveFromEmpty() {
-        OpenIntToDoubleHashMap map = new OpenIntToDoubleHashMap();
+        OpenLongToDoubleHashMap map = new OpenLongToDoubleHashMap();
         Assert.assertTrue(Double.isNaN(map.remove(50)));
     }
 
@@ -283,7 +283,7 @@ public class OpenLongToDoubleHashMapTest {
      */
     @Test
     public void testPutKeysWithCollisions() {
-        OpenIntToDoubleHashMap map = new OpenIntToDoubleHashMap();
+        OpenLongToDoubleHashMap map = new OpenLongToDoubleHashMap();
         int key1 = -1996012590;
         double value1 = 1.0;
         map.put(key1, value1);
@@ -307,8 +307,8 @@ public class OpenLongToDoubleHashMapTest {
      */
     @Test
     public void testPutKeysWithCollision2() {
-        OpenIntToDoubleHashMap map = new OpenIntToDoubleHashMap();
-        int key1 = 837989881;
+        OpenLongToDoubleHashMap map = new OpenLongToDoubleHashMap();
+        long key1 = 837989881;
         double value1 = 1.0;
         map.put(key1, value1);
         int key2 = 476463321;


### PR DESCRIPTION
Recently, I was using a sparse matrix to store co-occurrence statistics of words in a corpus. There are 50,000 unique words, and since 50,000^2 is greater than the maximum integer value, the OpenIntToDoubleHashMap of the OpenMapRealMatrix couldn't store it. I duplicated the 2 classes and changed the keys from integers to longs in 2 classes called OpenLongToDoubleHashMap and OpenMapBigRealMatrix. I also duplicated and updated the tests for the new classes.  