### PR TITLE
Remove the redundant null check expression of a non-null value lastRe…

### DIFF
--- a/src/main/java/org/apache/commons/math4/optim/nonlinear/scalar/noderiv/CMAESOptimizer.java
+++ b/src/main/java/org/apache/commons/math4/optim/nonlinear/scalar/noderiv/CMAESOptimizer.java
@@ -452,7 +452,7 @@ public class CMAESOptimizer
                 lastResult = optimum;
                 optimum = new PointValuePair(fitfun.repair(bestArx.getColumn(0)),
                                              isMinimize ? bestFitness : -bestFitness);
-                if (getConvergenceChecker() != null && lastResult != null &&
+                if (getConvergenceChecker() != null && 
                     getConvergenceChecker().converged(iterations, optimum, lastResult)) {
                     break generationLoop;
                 }


### PR DESCRIPTION
…sult.

The expression "lastResult != null" is a redundant check of a known non-null value because lastResult is non-null.
http://findbugs.sourceforge.net/bugDescriptions.html#RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE