### PR TITLE
Replace the inefficient Double constructor with static Double.valueOf() method.

### DIFF
--- a/src/main/java/org/apache/commons/math4/util/MathUtils.java
+++ b/src/main/java/org/apache/commons/math4/util/MathUtils.java
@@ -71,7 +71,7 @@ public final class MathUtils {
      * @return {@code new Double(x).equals(new Double(y))}
      */
     public static boolean equals(double x, double y) {
-        return new Double(x).equals(new Double(y));
+        return Double.valueOf(x).equals(Double.valueOf(y));
     }
 
     /**


### PR DESCRIPTION
Using new Double(double) is guaranteed to always result in a new object whereas Double.valueOf(double) allows caching of values to be done by the compiler, class library, or JVM.
Using of cached values avoids object allocation and the code will be faster.
http://findbugs.sourceforge.net/bugDescriptions.html#DM_FP_NUMBER_CTOR