### PR TITLE
Remove the useless condition "variablesToInclude.length > 1".

### DIFF
--- a/src/main/java/org/apache/commons/math4/stat/regression/SimpleRegression.java
+++ b/src/main/java/org/apache/commons/math4/stat/regression/SimpleRegression.java
@@ -827,7 +827,7 @@ public class SimpleRegression implements Serializable, UpdatingMultipleLinearReg
         if( variablesToInclude.length > 2 || (variablesToInclude.length > 1 && !hasIntercept) ){
             throw new ModelSpecificationException(
                     LocalizedFormats.ARRAY_SIZE_EXCEEDS_MAX_VARIABLES,
-                    (variablesToInclude.length > 1 && !hasIntercept) ? 1 : 2);
+                    (!hasIntercept) ? 1 : 2);
         }
 
         if( hasIntercept ){


### PR DESCRIPTION
The condition "variablesToInclude.length > 1" has no effect on the current statement.
This condition always produces the same result as the value of variablesToInclude.length was narrowed before.
http://findbugs.sourceforge.net/bugDescriptions.html#UC_USELESS_CONDITION