### PR TITLE
Consider returning a zero length array rather than null.

### DIFF
--- a/src/main/java/org/apache/commons/math4/stat/regression/MillerUpdatingRegression.java
+++ b/src/main/java/org/apache/commons/math4/stat/regression/MillerUpdatingRegression.java
@@ -496,7 +496,7 @@ public class MillerUpdatingRegression implements UpdatingMultipleLinearRegressio
      */
     private double[] cov(int nreq) {
         if (this.nobs <= nreq) {
-            return null;
+            return new double[0];
         }
         double rnk = 0.0;
         for (int i = 0; i < nreq; i++) {
@@ -625,7 +625,7 @@ public class MillerUpdatingRegression implements UpdatingMultipleLinearRegressio
         double sumyy;
         final int offXX = (nvars - in) * (nvars - in - 1) / 2;
         if (in < -1 || in >= nvars) {
-            return null;
+            return new double[0];
         }
         final int nvm = nvars - 1;
         final int base_pos = r.length - (nvm - in) * (nvm - in + 1) / 2;


### PR DESCRIPTION
It is often a better design to return a length zero array rather than a null reference to indicate that there are no results (i.e., an empty list of results).
This way, no explicit check for null is needed by clients of the method.
On the other hand, using null to indicate "there is no answer to this question" is probably appropriate.
http://findbugs.sourceforge.net/bugDescriptions.html#PZLA_PREFER_ZERO_LENGTH_ARRAYS