### PR TITLE
Some state change not take effect in BOBYQA's bobyqb and trsbox

### DIFF
--- a/src/main/java/org/apache/commons/math4/optim/nonlinear/scalar/noderiv/BOBYQAOptimizer.java
+++ b/src/main/java/org/apache/commons/math4/optim/nonlinear/scalar/noderiv/BOBYQAOptimizer.java
@@ -549,6 +549,8 @@ public class BOBYQAOptimizer
                         // throw new PathIsExploredException(); // XXX
                     }
                 }
+				// state 650 changed in for-loop should be check
+				if (state == 650) break;
                 state = 680; break;
             }
             ++ntrits;
@@ -2128,6 +2130,8 @@ public class BOBYQAOptimizer
                     }
                 }
             }
+			// state 100 changed in for-loop should be check
+			if (state == 100) break;
 
             // Calculate HHD and some curvatures for the alternative iteration.
 


### PR DESCRIPTION
In BOBYQA's bobyqb and trsbox algorithm, some state change not take effect beacuse of "break" just break the inner for-loop, not outer switch. This pull just deal with that.