### PR TITLE
(bugfix) EmpiricalDistribution cumulative probability returns NaN if bin doesn't have data points

### DIFF
--- a/src/main/java/org/apache/commons/math4/distribution/EmpiricalDistribution.java
+++ b/src/main/java/org/apache/commons/math4/distribution/EmpiricalDistribution.java
@@ -738,7 +738,7 @@ public class EmpiricalDistribution extends AbstractRealDistribution
      * @return within-bin kernel parameterized by bStats
      */
     protected ContinuousDistribution getKernel(SummaryStatistics bStats) {
-        if (bStats.getN() == 1 || bStats.getVariance() == 0) {
+        if (bStats.getN() <= 1 || bStats.getVariance() == 0) {
             return new ConstantContinuousDistribution(bStats.getMean());
         } else {
             return new NormalDistribution(bStats.getMean(), bStats.getStandardDeviation());


### PR DESCRIPTION
EmpiricalDistribution.cumulativeProbability returns NaN if bin doesn't have data points.
This may happened if underneath distribution is very skewed, which happened to me when I worked on one of projects in Indeed.com.

I reproduced bug in unit test and fixed it.