### PR TITLE
MATH-1449: PolygonsSet.getBarycenter() should return NaN for empty regions

### DIFF
--- a/src/main/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSet.java
+++ b/src/main/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSet.java
@@ -553,7 +553,7 @@ public class PolygonsSet extends AbstractRegion<Euclidean2D, Euclidean1D> {
                 setBarycenter((Point<Euclidean2D>) Cartesian2D.NaN);
             } else {
                 setSize(0);
-                setBarycenter((Point<Euclidean2D>) new Cartesian2D(0, 0));
+                setBarycenter((Point<Euclidean2D>) Cartesian2D.NaN);
             }
         } else if (v[0][0] == null) {
             // there is at least one open-loop: the polygon is infinite

--- a/src/test/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSetTest.java
+++ b/src/test/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSetTest.java
@@ -221,15 +221,28 @@ public class PolygonsSetTest {
 
     @Test
     public void testEmpty() {
-        PolygonsSet empty = (PolygonsSet) new RegionFactory<Euclidean2D>().getComplement(new PolygonsSet(1.0e-10));
-        Assert.assertTrue(empty.isEmpty());
-        Assert.assertEquals(0, empty.getVertices().length);
-        Assert.assertEquals(0.0, empty.getBoundarySize(), 1.0e-10);
-        Assert.assertEquals(0.0, empty.getSize(), 1.0e-10);
+        // act
+        PolygonsSet poly = (PolygonsSet) new RegionFactory<Euclidean2D>().getComplement(new PolygonsSet(1e-10));
+
+        // assert
+        Assert.assertEquals(1e-10, poly.getTolerance(), Precision.EPSILON);
+        Assert.assertEquals(0.0, poly.getSize(), 1e-10);
+        Assert.assertEquals(0.0, poly.getBoundarySize(), 1e-10);
+        Assert.assertEquals(0, poly.getVertices().length);
+        Assert.assertEquals(true, poly.isEmpty());
+        Assert.assertEquals(false, poly.isFull());
+        GeometryTestUtils.assertVectorEquals(Cartesian2D.NaN, (Cartesian2D) poly.getBarycenter(), 1e-10);
+
+        checkPoints(Region.Location.OUTSIDE, poly, new Cartesian2D[] {
+                new Cartesian2D(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY),
+                Cartesian2D.ZERO,
+                new Cartesian2D(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY)});
+
+
         for (double y = -1; y < 1; y += 0.1) {
             for (double x = -1; x < 1; x += 0.1) {
                 Assert.assertEquals(Double.POSITIVE_INFINITY,
-                                    empty.projectToBoundary(new Cartesian2D(x, y)).getOffset(),
+                                    poly.projectToBoundary(new Cartesian2D(x, y)).getOffset(),
                                     1.0e-10);
             }
         }
@@ -237,16 +250,28 @@ public class PolygonsSetTest {
 
     @Test
     public void testFull() {
-        PolygonsSet empty = new PolygonsSet(1.0e-10);
-        Assert.assertFalse(empty.isEmpty());
-        Assert.assertEquals(0, empty.getVertices().length);
-        Assert.assertEquals(0.0, empty.getBoundarySize(), 1.0e-10);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, empty.getSize(), 1.0e-10);
+        // act
+        PolygonsSet poly = new PolygonsSet(1e-10);
+
+        // assert
+        Assert.assertEquals(1e-10, poly.getTolerance(), Precision.EPSILON);
+        Assert.assertEquals(Double.POSITIVE_INFINITY, poly.getSize(), 1e-10);
+        Assert.assertEquals(0.0, poly.getBoundarySize(), 1e-10);
+        Assert.assertEquals(0, poly.getVertices().length);
+        Assert.assertEquals(false, poly.isEmpty());
+        Assert.assertEquals(true, poly.isFull());
+        GeometryTestUtils.assertVectorEquals(Cartesian2D.NaN, (Cartesian2D) poly.getBarycenter(), 1e-10);
+
+        checkPoints(Region.Location.INSIDE, poly, new Cartesian2D[] {
+                new Cartesian2D(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY),
+                Cartesian2D.ZERO,
+                new Cartesian2D(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY)});
+
         for (double y = -1; y < 1; y += 0.1) {
             for (double x = -1; x < 1; x += 0.1) {
                 Assert.assertEquals(Double.NEGATIVE_INFINITY,
-                                    empty.projectToBoundary(new Cartesian2D(x, y)).getOffset(),
-                                    1.0e-10);
+                                    poly.projectToBoundary(new Cartesian2D(x, y)).getOffset(),
+                                    1e-10);
             }
         }
     }

--- a/src/test/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSetTest.java
+++ b/src/test/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSetTest.java
@@ -229,8 +229,8 @@ public class PolygonsSetTest {
         Assert.assertEquals(0.0, poly.getSize(), 1e-10);
         Assert.assertEquals(0.0, poly.getBoundarySize(), 1e-10);
         Assert.assertEquals(0, poly.getVertices().length);
-        Assert.assertEquals(true, poly.isEmpty());
-        Assert.assertEquals(false, poly.isFull());
+        Assert.assertTrue(poly.isEmpty());
+        Assert.assertFalse(poly.isFull());
         GeometryTestUtils.assertVectorEquals(Cartesian2D.NaN, (Cartesian2D) poly.getBarycenter(), 1e-10);
 
         checkPoints(Region.Location.OUTSIDE, poly, new Cartesian2D[] {
@@ -238,12 +238,12 @@ public class PolygonsSetTest {
                 Cartesian2D.ZERO,
                 new Cartesian2D(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY)});
 
-
+        double offset;
         for (double y = -1; y < 1; y += 0.1) {
             for (double x = -1; x < 1; x += 0.1) {
-                Assert.assertEquals(Double.POSITIVE_INFINITY,
-                                    poly.projectToBoundary(new Cartesian2D(x, y)).getOffset(),
-                                    1.0e-10);
+                offset = poly.projectToBoundary(new Cartesian2D(x, y)).getOffset();
+                Assert.assertTrue(offset > 0);
+                Assert.assertTrue(Double.isInfinite(offset));
             }
         }
     }
@@ -255,11 +255,12 @@ public class PolygonsSetTest {
 
         // assert
         Assert.assertEquals(1e-10, poly.getTolerance(), Precision.EPSILON);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, poly.getSize(), 1e-10);
+        Assert.assertTrue(poly.getSize() > 0);
+        Assert.assertTrue(Double.isInfinite(poly.getSize()));
         Assert.assertEquals(0.0, poly.getBoundarySize(), 1e-10);
         Assert.assertEquals(0, poly.getVertices().length);
-        Assert.assertEquals(false, poly.isEmpty());
-        Assert.assertEquals(true, poly.isFull());
+        Assert.assertFalse(poly.isEmpty());
+        Assert.assertTrue(poly.isFull());
         GeometryTestUtils.assertVectorEquals(Cartesian2D.NaN, (Cartesian2D) poly.getBarycenter(), 1e-10);
 
         checkPoints(Region.Location.INSIDE, poly, new Cartesian2D[] {
@@ -267,11 +268,12 @@ public class PolygonsSetTest {
                 Cartesian2D.ZERO,
                 new Cartesian2D(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY)});
 
+        double offset;
         for (double y = -1; y < 1; y += 0.1) {
             for (double x = -1; x < 1; x += 0.1) {
-                Assert.assertEquals(Double.NEGATIVE_INFINITY,
-                                    poly.projectToBoundary(new Cartesian2D(x, y)).getOffset(),
-                                    1e-10);
+                offset = poly.projectToBoundary(new Cartesian2D(x, y)).getOffset();
+                Assert.assertTrue(offset < 0);
+                Assert.assertTrue(Double.isInfinite(offset));
             }
         }
     }


### PR DESCRIPTION
The PolygonsSet.getBarycenter() method is currently returning (0, 0) as the barycenter for empty regions. It should return (NaN, NaN) since the barycenter does not exist and this is the behavior of the other region classes, IntervalsSet and PolyhedronsSet.