### PR TITLE
MATH-1450: Fixing PolygonsSet to return correct last vertex for open loops

### DIFF
--- a/src/main/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSet.java
+++ b/src/main/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSet.java
@@ -689,9 +689,7 @@ public class PolygonsSet extends AbstractRegion<Euclidean2D, Euclidean1D> {
                             if (j < (array.length - 1)) {
                                 // current point
                                 array[j++] = segment.getEnd();
-                            }
-
-                            if (j == (array.length - 1)) {
+                            } else if (j == (array.length - 1)) {
                                 // last dummy point
                                 double x = segment.getLine().toSubSpace(segment.getStart()).getX();
                                 x += FastMath.max(1.0, FastMath.abs(x / 2));

--- a/src/test/java/org/apache/commons/math4/geometry/GeometryTestUtils.java
+++ b/src/test/java/org/apache/commons/math4/geometry/GeometryTestUtils.java
@@ -19,6 +19,7 @@ package org.apache.commons.math4.geometry;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.math3.util.FastMath;
 import org.apache.commons.math4.geometry.euclidean.oned.Cartesian1D;
@@ -81,6 +82,24 @@ public class GeometryTestUtils {
         Assert.assertEquals(msg, expected.getX(), actual.getX(), tolerance);
         Assert.assertEquals(msg, expected.getY(), actual.getY(), tolerance);
         Assert.assertEquals(msg, expected.getZ(), actual.getZ(), tolerance);
+    }
+
+    /** Asserts that the given value is positive infinity.
+     * @param value
+     */
+    public static void assertPositiveInfinity(double value) {
+        String msg = "Expected value to be positive infinity but was " + value;
+        Assert.assertTrue(msg, Double.isInfinite(value));
+        Assert.assertTrue(msg, value > 0);
+    }
+
+    /** Asserts that the given value is negative infinity..
+     * @param value
+     */
+    public static void assertNegativeInfinity(double value) {
+        String msg = "Expected value to be negative infinity but was " + value;
+        Assert.assertTrue(msg, Double.isInfinite(value));
+        Assert.assertTrue(msg, value < 0);
     }
 
     /** Prints a string representation of the given 1D {@link BSPTree} to
@@ -188,7 +207,20 @@ public class GeometryTestUtils {
                 }
             }
 
-            write(node.getClass().getSimpleName() + "@" + System.identityHashCode(node) + " | ");
+            write(nodeIdString(node) + " | ");
+        }
+
+        /** Returns a short string identifier for the given node.
+         * @param node
+         * @return
+         */
+        protected String nodeIdString(BSPTree<S> node) {
+            String str = Objects.toString(node);
+            int idx = str.lastIndexOf('.');
+            if (idx > -1) {
+                return str.substring(idx + 1, str.length());
+            }
+            return str;
         }
 
         /** Adds the given string to the output.

--- a/src/test/java/org/apache/commons/math4/geometry/euclidean/oned/IntervalTest.java
+++ b/src/test/java/org/apache/commons/math4/geometry/euclidean/oned/IntervalTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.geometry.euclidean.oned;
 
+import org.apache.commons.math4.geometry.GeometryTestUtils;
 import org.apache.commons.math4.geometry.euclidean.oned.Interval;
 import org.apache.commons.math4.geometry.partitioning.Region;
 import org.apache.commons.math4.util.FastMath;
@@ -114,8 +115,8 @@ public class IntervalTest {
             Assert.assertEquals(Region.Location.INSIDE,
                                 interval.checkPoint(-1 * FastMath.pow(10.0, e), TEST_TOLERANCE));
         }
-        Assert.assertEquals(Double.POSITIVE_INFINITY, interval.getSize(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, interval.getInf(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(interval.getSize());
+        GeometryTestUtils.assertNegativeInfinity(interval.getInf());
         Assert.assertEquals(9.0, interval.getSup(), TEST_TOLERANCE);
     }
 
@@ -131,9 +132,9 @@ public class IntervalTest {
             Assert.assertEquals(Region.Location.INSIDE,
                                 interval.checkPoint(FastMath.pow(10.0, e), TEST_TOLERANCE));
         }
-        Assert.assertEquals(Double.POSITIVE_INFINITY, interval.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(interval.getSize());
         Assert.assertEquals(9.0, interval.getInf(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, interval.getSup(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(interval.getSup());
     }
 
     @Test
@@ -146,9 +147,9 @@ public class IntervalTest {
             Assert.assertEquals(Region.Location.INSIDE,
                                 interval.checkPoint(FastMath.pow(10.0, e), TEST_TOLERANCE));
         }
-        Assert.assertEquals(Double.POSITIVE_INFINITY, interval.getSize(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, interval.getInf(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, interval.getSup(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(interval.getSize());
+        GeometryTestUtils.assertNegativeInfinity(interval.getInf());
+        GeometryTestUtils.assertPositiveInfinity(interval.getSup());
     }
 
     @Test
@@ -167,8 +168,8 @@ public class IntervalTest {
         Interval interval = new Interval(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
 
         // assert
-        Assert.assertEquals(Double.NaN, interval.getSize(), Precision.SAFE_MIN); // inf - inf = NaN according to floating point spec
-        Assert.assertEquals(Double.POSITIVE_INFINITY, interval.getBarycenter(), Precision.EPSILON);
+        Assert.assertTrue(Double.isNaN(interval.getSize())); // inf - inf = NaN according to floating point spec
+        GeometryTestUtils.assertPositiveInfinity(interval.getBarycenter());
     }
 
     @Test
@@ -177,7 +178,7 @@ public class IntervalTest {
         Interval interval = new Interval(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
 
         // assert
-        Assert.assertEquals(Double.NaN, interval.getSize(), Precision.SAFE_MIN); // inf - inf = NaN according to floating point spec
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, interval.getBarycenter(), Precision.EPSILON);
+        Assert.assertTrue(Double.isNaN(interval.getSize())); // inf - inf = NaN according to floating point spec
+        GeometryTestUtils.assertNegativeInfinity(interval.getBarycenter());
     }
 }

--- a/src/test/java/org/apache/commons/math4/geometry/euclidean/oned/IntervalsSetTest.java
+++ b/src/test/java/org/apache/commons/math4/geometry/euclidean/oned/IntervalsSetTest.java
@@ -41,9 +41,9 @@ public class IntervalsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, set.getTolerance(), Precision.SAFE_MIN);
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, set.getInf(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertNegativeInfinity(set.getInf());
+        GeometryTestUtils.assertPositiveInfinity(set.getSup());
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian1D.NaN, (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 
@@ -69,9 +69,9 @@ public class IntervalsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, set.getTolerance(), Precision.SAFE_MIN);
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, set.getInf(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertNegativeInfinity(set.getInf());
+        GeometryTestUtils.assertPositiveInfinity(set.getSup());
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian1D.NaN, (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 
@@ -98,8 +98,8 @@ public class IntervalsSetTest {
         // assert
         Assert.assertEquals(TEST_TOLERANCE, set.getTolerance(), Precision.SAFE_MIN);
         Assert.assertEquals(9.0, set.getInf(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(set.getSup());
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian1D.NaN, (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 
@@ -122,9 +122,9 @@ public class IntervalsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, set.getTolerance(), Precision.SAFE_MIN);
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, set.getInf(), TEST_TOLERANCE);
+        GeometryTestUtils.assertNegativeInfinity(set.getInf());
         Assert.assertEquals(9.0, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian1D.NaN, (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 
@@ -200,9 +200,9 @@ public class IntervalsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, set.getTolerance(), Precision.SAFE_MIN);
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, set.getInf(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertNegativeInfinity(set.getInf());
+        GeometryTestUtils.assertPositiveInfinity(set.getSup());
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian1D.NaN, (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 
@@ -233,8 +233,8 @@ public class IntervalsSetTest {
         // assert
         Assert.assertEquals(TEST_TOLERANCE, set.getTolerance(), Precision.SAFE_MIN);
         Assert.assertEquals(9.0, set.getInf(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(set.getSup());
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian1D.NaN, (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 
@@ -261,9 +261,9 @@ public class IntervalsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, set.getTolerance(), Precision.SAFE_MIN);
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, set.getInf(), TEST_TOLERANCE);
+        GeometryTestUtils.assertNegativeInfinity(set.getInf());
         Assert.assertEquals(9.0, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian1D.NaN, (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 
@@ -362,9 +362,9 @@ public class IntervalsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, set.getTolerance(), Precision.SAFE_MIN);
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, set.getInf(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertNegativeInfinity(set.getInf());
+        GeometryTestUtils.assertPositiveInfinity(set.getSup());
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(new Cartesian1D(Double.NaN), (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 
@@ -403,9 +403,9 @@ public class IntervalsSetTest {
 
         // assert
         Assert.assertEquals(tolerance, set.getTolerance(), Precision.SAFE_MIN);
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, set.getInf(), TEST_TOLERANCE);
+        GeometryTestUtils.assertNegativeInfinity(set.getInf());
         Assert.assertEquals(first, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian1D.NaN, (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 
@@ -434,8 +434,8 @@ public class IntervalsSetTest {
         // assert
         Assert.assertEquals(tolerance, set.getTolerance(), Precision.SAFE_MIN);
         Assert.assertEquals(first, set.getInf(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSup(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(set.getSup());
+        GeometryTestUtils.assertPositiveInfinity(set.getSize());
         Assert.assertEquals(0.0, set.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian1D.NaN, (Cartesian1D) set.getBarycenter(), TEST_TOLERANCE);
 

--- a/src/test/java/org/apache/commons/math4/geometry/euclidean/oned/OrientedPointTest.java
+++ b/src/test/java/org/apache/commons/math4/geometry/euclidean/oned/OrientedPointTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.math4.geometry.euclidean.oned;
 
 import org.junit.Test;
 import org.apache.commons.math3.util.Precision;
+import org.apache.commons.math4.geometry.GeometryTestUtils;
 import org.apache.commons.math4.geometry.Point;
 import org.apache.commons.math4.geometry.Vector;
 import org.junit.Assert;
@@ -31,7 +32,7 @@ public class OrientedPointTest {
 
         // assert
         Assert.assertEquals(2.0, pt.getLocation().getX(), Precision.EPSILON);
-        Assert.assertEquals(true, pt.isDirect());
+        Assert.assertTrue(pt.isDirect());
         Assert.assertEquals(1e-5, pt.getTolerance(), Precision.EPSILON);
     }
 
@@ -46,7 +47,7 @@ public class OrientedPointTest {
         // assert
         Assert.assertSame(orig, copy);
         Assert.assertEquals(2.0, copy.getLocation().getX(), Precision.EPSILON);
-        Assert.assertEquals(true, copy.isDirect());
+        Assert.assertTrue(copy.isDirect());
         Assert.assertEquals(1e-5, copy.getTolerance(), Precision.EPSILON);
     }
 
@@ -132,8 +133,8 @@ public class OrientedPointTest {
         IntervalsSet set = pt.wholeSpace();
 
         // assert
-        Assert.assertEquals(Double.NEGATIVE_INFINITY, set.getInf(), Precision.EPSILON);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, set.getSup(), Precision.EPSILON);
+        GeometryTestUtils.assertNegativeInfinity(set.getInf());
+        GeometryTestUtils.assertPositiveInfinity(set.getSup());
     }
 
     @Test
@@ -145,16 +146,16 @@ public class OrientedPointTest {
         OrientedPoint direct2 = new OrientedPoint(new Cartesian1D(1.0), true, 1e-5);
 
         // act/assert
-        Assert.assertEquals(true, notDirect1.sameOrientationAs(notDirect1));
-        Assert.assertEquals(true, notDirect1.sameOrientationAs(notDirect2));
-        Assert.assertEquals(true, notDirect2.sameOrientationAs(notDirect1));
+        Assert.assertTrue(notDirect1.sameOrientationAs(notDirect1));
+        Assert.assertTrue(notDirect1.sameOrientationAs(notDirect2));
+        Assert.assertTrue(notDirect2.sameOrientationAs(notDirect1));
 
-        Assert.assertEquals(true, direct1.sameOrientationAs(direct1));
-        Assert.assertEquals(true, direct1.sameOrientationAs(direct2));
-        Assert.assertEquals(true, direct2.sameOrientationAs(direct1));
+        Assert.assertTrue(direct1.sameOrientationAs(direct1));
+        Assert.assertTrue(direct1.sameOrientationAs(direct2));
+        Assert.assertTrue(direct2.sameOrientationAs(direct1));
 
-        Assert.assertEquals(false, notDirect1.sameOrientationAs(direct1));
-        Assert.assertEquals(false, direct1.sameOrientationAs(notDirect1));
+        Assert.assertFalse(notDirect1.sameOrientationAs(direct1));
+        Assert.assertFalse(direct1.sameOrientationAs(notDirect1));
     }
 
     @Test
@@ -179,7 +180,7 @@ public class OrientedPointTest {
 
         // assert
         Assert.assertEquals(2.0, pt.getLocation().getX(), Precision.EPSILON);
-        Assert.assertEquals(false, pt.isDirect());
+        Assert.assertFalse(pt.isDirect());
         Assert.assertEquals(1e-5, pt.getTolerance(), Precision.EPSILON);
 
         Assert.assertEquals(1, pt.getOffset((Vector<Euclidean1D>) new Cartesian1D(1.0)), Precision.EPSILON);

--- a/src/test/java/org/apache/commons/math4/geometry/euclidean/threed/PolyhedronsSetTest.java
+++ b/src/test/java/org/apache/commons/math4/geometry/euclidean/threed/PolyhedronsSetTest.java
@@ -63,11 +63,11 @@ public class PolyhedronsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, polySet.getTolerance(), Precision.EPSILON);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, polySet.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(polySet.getSize());
         Assert.assertEquals(0.0, polySet.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian3D.NaN, (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(true, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertTrue(polySet.isFull());
 
         checkPoints(Region.Location.INSIDE, polySet,
                 new Cartesian3D(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE),
@@ -87,8 +87,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(0.0, polySet.getSize(), TEST_TOLERANCE);
         Assert.assertEquals(0.0, polySet.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian3D.NaN, (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(true, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertTrue(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.OUTSIDE, polySet,
                 new Cartesian3D(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE),
@@ -110,11 +110,11 @@ public class PolyhedronsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, polySet.getTolerance(), Precision.EPSILON);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, polySet.getSize(), TEST_TOLERANCE);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, polySet.getBoundarySize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(polySet.getSize());
+        GeometryTestUtils.assertPositiveInfinity(polySet.getBoundarySize());
         GeometryTestUtils.assertVectorEquals(Cartesian3D.NaN, (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.INSIDE, polySet,
                 new Cartesian3D(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE),
@@ -136,11 +136,11 @@ public class PolyhedronsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, polySet.getTolerance(), Precision.EPSILON);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, polySet.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(polySet.getSize());
         Assert.assertEquals(6, polySet.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian3D.NaN, (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.INSIDE, polySet,
                 new Cartesian3D(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE),
@@ -161,11 +161,11 @@ public class PolyhedronsSetTest {
 
         // assert
         Assert.assertEquals(TEST_TOLERANCE, polySet.getTolerance(), Precision.EPSILON);
-        Assert.assertEquals(Double.POSITIVE_INFINITY, polySet.getSize(), TEST_TOLERANCE);
+        GeometryTestUtils.assertPositiveInfinity(polySet.getSize());
         Assert.assertEquals(0.0, polySet.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian3D.NaN, (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(true, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertTrue(polySet.isFull());
     }
 
     @Test
@@ -181,8 +181,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(1.0, polySet.getSize(), TEST_TOLERANCE);
         Assert.assertEquals(6.0, polySet.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian3D.ZERO, (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.OUTSIDE, polySet,
                 new Cartesian3D(-1, 0, 0),
@@ -246,8 +246,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(2.0, polySet.getSize(), TEST_TOLERANCE);
         Assert.assertEquals(12.0, polySet.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(new Cartesian3D(1, 0, 0), (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.OUTSIDE, polySet,
                 new Cartesian3D(-1, 0, 0),
@@ -274,8 +274,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(2.0, polySet.getSize(), TEST_TOLERANCE);
         Assert.assertEquals(10.0, polySet.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(new Cartesian3D(0.5, 0, 0), (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.OUTSIDE, polySet,
                 new Cartesian3D(-1, 0, 0),
@@ -302,8 +302,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(2.0, polySet.getSize(), tolerance);
         Assert.assertEquals(10.0, polySet.getBoundarySize(), tolerance);
         GeometryTestUtils.assertVectorEquals(new Cartesian3D(0.5 + 5e-8, 0, 0), (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.OUTSIDE, polySet,
                 new Cartesian3D(-1, 0, 0),
@@ -329,8 +329,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(2.0, polySet.getSize(), TEST_TOLERANCE);
         Assert.assertEquals(12.0, polySet.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(new Cartesian3D(0.5, 0.5, 0), (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.OUTSIDE, polySet,
                 new Cartesian3D(-1, 0, 0),
@@ -358,8 +358,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(2.0, polySet.getSize(), TEST_TOLERANCE);
         Assert.assertEquals(12.0, polySet.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(new Cartesian3D(0.5, 0.5, 0.5), (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.OUTSIDE, polySet,
                 new Cartesian3D(-1, 0, 0),
@@ -421,13 +421,13 @@ public class PolyhedronsSetTest {
         tree = (PolyhedronsSet) new RegionFactory<Euclidean3D>().getComplement(tree);
 
         // assert
-        Assert.assertEquals(Double.POSITIVE_INFINITY, tree.getSize(), 1.0e-10);
+        GeometryTestUtils.assertPositiveInfinity(tree.getSize());
         Assert.assertEquals(6.0, tree.getBoundarySize(), 1.0e-10);
 
         Cartesian3D barycenter = (Cartesian3D) tree.getBarycenter();
-        Assert.assertEquals(Double.NaN, barycenter.getX(), 1.0e-10);
-        Assert.assertEquals(Double.NaN, barycenter.getY(), 1.0e-10);
-        Assert.assertEquals(Double.NaN, barycenter.getZ(), 1.0e-10);
+        Assert.assertTrue(Double.isNaN(barycenter.getX()));
+        Assert.assertTrue(Double.isNaN(barycenter.getY()));
+        Assert.assertTrue(Double.isNaN(barycenter.getZ()));
 
         for (double x = -0.25; x < 1.25; x += 0.1) {
             boolean xOK = (x < 0.0) || (x > 1.0);
@@ -510,8 +510,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(sphereVolume(radius), polySet.getSize(), approximationTolerance);
         Assert.assertEquals(sphereSurface(radius), polySet.getBoundarySize(), approximationTolerance);
         GeometryTestUtils.assertVectorEquals(new Cartesian3D(1, 2, 3), (Cartesian3D) polySet.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, polySet.isEmpty());
-        Assert.assertEquals(false, polySet.isFull());
+        Assert.assertFalse(polySet.isEmpty());
+        Assert.assertFalse(polySet.isFull());
 
         checkPoints(Region.Location.OUTSIDE, polySet,
                 new Cartesian3D(-0.1, 2, 3),
@@ -952,8 +952,8 @@ public class PolyhedronsSetTest {
                 result.getSize(), tolerance);
         Assert.assertEquals(cubeSurface(size) - circleSurface(radius) + (0.5 * sphereSurface(radius)),
                 result.getBoundarySize(), tolerance);
-        Assert.assertEquals(false, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-0.1, 0.5, 0.5),
@@ -987,8 +987,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(sphereVolume(radius), result.getSize(), tolerance);
         Assert.assertEquals(sphereSurface(radius), result.getBoundarySize(), tolerance);
         GeometryTestUtils.assertVectorEquals(Cartesian3D.ZERO, (Cartesian3D) result.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-1.1, 0, 0),
@@ -1026,8 +1026,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals((sphereVolume(radius) * 0.5), result.getSize(), tolerance);
         Assert.assertEquals(circleSurface(radius) + (0.5 * sphereSurface(radius)),
                 result.getBoundarySize(), tolerance);
-        Assert.assertEquals(false, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-0.1, 0.5, 1.0),
@@ -1061,8 +1061,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(sphereVolume(radius), result.getSize(), tolerance);
         Assert.assertEquals(sphereSurface(radius), result.getBoundarySize(), tolerance);
         GeometryTestUtils.assertVectorEquals(Cartesian3D.ZERO, (Cartesian3D) result.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(false, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-1.1, 0, 0),
@@ -1104,8 +1104,8 @@ public class PolyhedronsSetTest {
 
         // assert
         Assert.assertEquals(2 * cubeSurface(size), result.getBoundarySize(), TEST_TOLERANCE);
-        Assert.assertEquals(false, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-0.1, -0.1, -0.1),
@@ -1144,8 +1144,8 @@ public class PolyhedronsSetTest {
         // assert
         Assert.assertEquals(cubeSurface(size) + (sphereSurface(radius)),
                 result.getBoundarySize(), tolerance);
-        Assert.assertEquals(false, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-0.1, 0.5, 0.5),
@@ -1179,8 +1179,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(0.0, result.getSize(), TEST_TOLERANCE);
         Assert.assertEquals(0.0, result.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian3D.NaN, (Cartesian3D) result.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(true, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertTrue(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-1.1, 0, 0),
@@ -1216,8 +1216,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(cubeVolume(size) - (sphereVolume(radius) * 0.5), result.getSize(), tolerance);
         Assert.assertEquals(cubeSurface(size) - circleSurface(radius) + (0.5 * sphereSurface(radius)),
                 result.getBoundarySize(), tolerance);
-        Assert.assertEquals(false, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-0.1, 0.5, 1.0),
@@ -1250,8 +1250,8 @@ public class PolyhedronsSetTest {
         Assert.assertEquals(0.0, result.getSize(), TEST_TOLERANCE);
         Assert.assertEquals(0.0, result.getBoundarySize(), TEST_TOLERANCE);
         GeometryTestUtils.assertVectorEquals(Cartesian3D.NaN, (Cartesian3D) result.getBarycenter(), TEST_TOLERANCE);
-        Assert.assertEquals(true, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertTrue(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-1.1, 0, 0),
@@ -1294,8 +1294,8 @@ public class PolyhedronsSetTest {
                 result.getSize(), tolerance);
         Assert.assertEquals(cubeSurface(size) - (3.0 * circleSurface(radius)) + (1.5 * sphereSurface(radius)),
                 result.getBoundarySize(), tolerance);
-        Assert.assertEquals(false, result.isEmpty());
-        Assert.assertEquals(false, result.isFull());
+        Assert.assertFalse(result.isEmpty());
+        Assert.assertFalse(result.isFull());
 
         checkPoints(Region.Location.OUTSIDE, result,
                 new Cartesian3D(-0.1, 0.5, 0.5),

--- a/src/test/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSetTest.java
+++ b/src/test/java/org/apache/commons/math4/geometry/euclidean/twod/PolygonsSetTest.java
@@ -191,7 +191,7 @@ public class PolygonsSetTest {
         checkPointsEqual(new Cartesian2D(0, 1), loop[1], tolerance);
         checkPointsEqual(new Cartesian2D(0, 0), loop[2], tolerance);
         checkPointsEqual(new Cartesian2D(1, 0), loop[3], tolerance);
-        checkPointsEqual(new Cartesian2D(1, 0), loop[4], tolerance);
+        checkPointsEqual(new Cartesian2D(1, 1), loop[4], tolerance);
     }
 
     @Test


### PR DESCRIPTION
Currently, the PolygonsSet.getVertices() method returns a point from the second-to-last edge as the last vertex in open loops. This makes it impossible to determine the direction of the last edge. This commit updates the code to use a vertex from the last edge as desired.