### PR TITLE
MATH-1416: Use Complex factory methods

### DIFF
--- a/src/main/java/org/apache/commons/math4/analysis/solvers/LaguerreSolver.java
+++ b/src/main/java/org/apache/commons/math4/analysis/solvers/LaguerreSolver.java
@@ -149,7 +149,7 @@ public class LaguerreSolver extends AbstractPolynomialSolver {
     private double laguerre(double lo, double hi) {
         final Complex c[] = ComplexUtils.real2Complex(getCoefficients());
 
-        final Complex initial = new Complex(0.5 * (lo + hi), 0);
+        final Complex initial = Complex.ofCartesian(0.5 * (lo + hi), 0);
         final Complex z = complexSolver.solve(c, initial);
         if (complexSolver.isRoot(lo, hi, z)) {
             return z.getReal();
@@ -194,7 +194,7 @@ public class LaguerreSolver extends AbstractPolynomialSolver {
               Double.POSITIVE_INFINITY,
               initial);
         return complexSolver.solveAll(ComplexUtils.real2Complex(coefficients),
-                                      new Complex(initial, 0d));
+                                      Complex.ofCartesian(initial, 0d));
     }
 
     /**
@@ -224,7 +224,7 @@ public class LaguerreSolver extends AbstractPolynomialSolver {
               Double.POSITIVE_INFINITY,
               initial);
         return complexSolver.solve(ComplexUtils.real2Complex(coefficients),
-                                   new Complex(initial, 0d));
+                                   Complex.ofCartesian(initial, 0d));
     }
 
     /**
@@ -328,11 +328,11 @@ public class LaguerreSolver extends AbstractPolynomialSolver {
             final double relativeAccuracy = getRelativeAccuracy();
             final double functionValueAccuracy = getFunctionValueAccuracy();
 
-            final Complex nC  = new Complex(n, 0);
-            final Complex n1C = new Complex(n - 1, 0);
+            final Complex nC  = Complex.ofCartesian(n, 0);
+            final Complex n1C = Complex.ofCartesian(n - 1, 0);
 
             Complex z = initial;
-            Complex oldz = new Complex(Double.POSITIVE_INFINITY,
+            Complex oldz = Complex.ofCartesian(Double.POSITIVE_INFINITY,
                                        Double.POSITIVE_INFINITY);
             while (true) {
                 // Compute pv (polynomial value), dv (derivative value), and
@@ -345,7 +345,7 @@ public class LaguerreSolver extends AbstractPolynomialSolver {
                     dv = pv.add(z.multiply(dv));
                     pv = coefficients[j].add(z.multiply(pv));
                 }
-                d2v = d2v.multiply(new Complex(2.0, 0.0));
+                d2v = d2v.multiply(Complex.ofCartesian(2.0, 0.0));
 
                 // Check for convergence.
                 final double tolerance = FastMath.max(relativeAccuracy * z.abs(),
@@ -369,9 +369,9 @@ public class LaguerreSolver extends AbstractPolynomialSolver {
                 final Complex denominator = dplus.abs() > dminus.abs() ? dplus : dminus;
                 // Perturb z if denominator is zero, for instance,
                 // p(x) = x^3 + 1, z = 0.
-                if (denominator.equals(new Complex(0.0, 0.0))) {
-                    z = z.add(new Complex(absoluteAccuracy, absoluteAccuracy));
-                    oldz = new Complex(Double.POSITIVE_INFINITY,
+                if (denominator.equals(Complex.ofCartesian(0.0, 0.0))) {
+                    z = z.add(Complex.ofCartesian(absoluteAccuracy, absoluteAccuracy));
+                    oldz = Complex.ofCartesian(Double.POSITIVE_INFINITY,
                                        Double.POSITIVE_INFINITY);
                 } else {
                     oldz = z;

--- a/src/main/java/org/apache/commons/math4/complex/ComplexFormat.java
+++ b/src/main/java/org/apache/commons/math4/complex/ComplexFormat.java
@@ -187,7 +187,7 @@ public class ComplexFormat {
      * @return A formatted number.
      */
     public String format(Double c) {
-        return format(new Complex(c, 0), new StringBuffer(), new FieldPosition(0)).toString();
+        return format(Complex.ofCartesian(c, 0), new StringBuffer(), new FieldPosition(0)).toString();
     }
 
     /**
@@ -272,7 +272,7 @@ public class ComplexFormat {
         if (obj instanceof Complex) {
             ret = format( (Complex)obj, toAppendTo, pos);
         } else if (obj instanceof Number) {
-            ret = format(new Complex(((Number)obj).doubleValue(), 0.0),
+            ret = format(Complex.ofCartesian(((Number)obj).doubleValue(), 0.0),
                          toAppendTo, pos);
         } else {
             throw new MathIllegalArgumentException(LocalizedFormats.CANNOT_FORMAT_INSTANCE_AS_COMPLEX,
@@ -389,7 +389,7 @@ public class ComplexFormat {
         case 0 :
             // no sign
             // return real only complex number
-            return new Complex(re.doubleValue(), 0.0);
+            return Complex.ofCartesian(re.doubleValue(), 0.0);
         case '-' :
             sign = -1;
             break;
@@ -422,7 +422,7 @@ public class ComplexFormat {
             return null;
         }
 
-        return new Complex(re.doubleValue(), im.doubleValue() * sign);
+        return Complex.ofCartesian(re.doubleValue(), im.doubleValue() * sign);
 
     }
 }

--- a/src/main/java/org/apache/commons/math4/complex/ComplexUtils.java
+++ b/src/main/java/org/apache/commons/math4/complex/ComplexUtils.java
@@ -64,7 +64,7 @@ public class ComplexUtils {
         if (r < 0) {
             throw new MathIllegalArgumentException(LocalizedFormats.NEGATIVE_COMPLEX_MODULE, r);
         }
-        return new Complex(r * FastMath.cos(theta), r * FastMath.sin(theta));
+        return Complex.ofCartesian(r * FastMath.cos(theta), r * FastMath.sin(theta));
     }
 
     /**
@@ -85,7 +85,7 @@ public class ComplexUtils {
             if (r[x] < 0) {
                 throw new MathIllegalArgumentException(LocalizedFormats.NEGATIVE_COMPLEX_MODULE, r[x]);
             }
-            c[x] = new Complex(r[x] * FastMath.cos(theta[x]), r[x] * FastMath.sin(theta[x]));
+            c[x] = Complex.ofCartesian(r[x] * FastMath.cos(theta[x]), r[x] * FastMath.sin(theta[x]));
         }
         return c;
     }
@@ -140,7 +140,7 @@ public class ComplexUtils {
      * @since 4.0
      */
     public static Complex extractComplexFromRealArray(double[] real, int index) {
-        return new Complex(real[index]);
+        return Complex.ofCartesian(real[index]);
     }
 
     /**
@@ -154,7 +154,7 @@ public class ComplexUtils {
      * @since 4.0
      */
     public static Complex extractComplexFromRealArray(float[] real, int index) {
-        return new Complex(real[index]);
+        return Complex.ofCartesian(real[index]);
     }
 
     /**
@@ -168,7 +168,7 @@ public class ComplexUtils {
      * @since 4.0
      */
     public static Complex extractComplexFromImaginaryArray(double[] imaginary, int index) {
-        return new Complex(0, imaginary[index]);
+        return Complex.ofCartesian(0, imaginary[index]);
     }
 
     /**
@@ -182,7 +182,7 @@ public class ComplexUtils {
      * @since 4.0
      */
     public static Complex extractComplexFromImaginaryArray(float[] imaginary, int index) {
-        return new Complex(0, imaginary[index]);
+        return Complex.ofCartesian(0, imaginary[index]);
     }
 
     /**
@@ -246,13 +246,13 @@ public class ComplexUtils {
      * {@code index}.
      *
      * @param d array of interleaved complex numbers alternating real and imaginary values
-     * @param index location in the array This is the location by complex number, e.g. index number 5 in the array will return {@code new Complex(d[10], d[11])}
+     * @param index location in the array This is the location by complex number, e.g. index number 5 in the array will return {@code Complex.ofCartesian(d[10], d[11])}
      * @return {@code Complex}.
      *
      * @since 4.0
      */
     public static Complex extractComplexFromInterleavedArray(double[] d, int index) {
-        return new Complex(d[index * 2], d[index * 2 + 1]);
+        return Complex.ofCartesian(d[index * 2], d[index * 2 + 1]);
     }
 
     /**
@@ -260,13 +260,13 @@ public class ComplexUtils {
      * {@code index}.
      *
      * @param f float array of interleaved complex numbers alternating real and imaginary values
-     * @param index location in the array This is the location by complex number, e.g. index number 5 in the {@code float[]} array will return new {@code Complex(d[10], d[11])}
+     * @param index location in the array This is the location by complex number, e.g. index number 5 in the {@code float[]} array will return {@code Complex.ofCartesian(d[10], d[11])}
      * @return {@code Complex}.
      *
      * @since 4.0
      */
     public static Complex extractComplexFromInterleavedArray(float[] f, int index) {
-        return new Complex(f[index * 2], f[index * 2 + 1]);
+        return Complex.ofCartesian(f[index * 2], f[index * 2 + 1]);
     }
 
     /**
@@ -439,7 +439,7 @@ public class ComplexUtils {
         int index = 0;
         final Complex c[] = new Complex[real.length];
         for (double d : real) {
-            c[index] = new Complex(d);
+            c[index] = Complex.ofCartesian(d);
             index++;
         }
         return c;
@@ -457,7 +457,7 @@ public class ComplexUtils {
         int index = 0;
         final Complex c[] = new Complex[real.length];
         for (float d : real) {
-            c[index] = new Complex(d);
+            c[index] = Complex.ofCartesian(d);
             index++;
         }
         return c;
@@ -879,7 +879,7 @@ public class ComplexUtils {
         int index = 0;
         final Complex c[] = new Complex[imaginary.length];
         for (double d : imaginary) {
-            c[index] = new Complex(0, d);
+            c[index] = Complex.ofCartesian(0, d);
             index++;
         }
         return c;
@@ -897,7 +897,7 @@ public class ComplexUtils {
         int index = 0;
         final Complex c[] = new Complex[imaginary.length];
         for (float d : imaginary) {
-            c[index] = new Complex(0, d);
+            c[index] = Complex.ofCartesian(0, d);
             index++;
         }
         return c;
@@ -1329,7 +1329,7 @@ public class ComplexUtils {
         final int length = interleaved.length / 2;
         final Complex c[] = new Complex[length];
         for (int n = 0; n < length; n++) {
-            c[n] = new Complex(interleaved[n * 2], interleaved[n * 2 + 1]);
+            c[n] = Complex.ofCartesian(interleaved[n * 2], interleaved[n * 2 + 1]);
         }
         return c;
     }
@@ -1347,7 +1347,7 @@ public class ComplexUtils {
         final int length = interleaved.length / 2;
         final Complex c[] = new Complex[length];
         for (int n = 0; n < length; n++) {
-            c[n] = new Complex(interleaved[n * 2], interleaved[n * 2 + 1]);
+            c[n] = Complex.ofCartesian(interleaved[n * 2], interleaved[n * 2 + 1]);
         }
         return c;
     }
@@ -1819,14 +1819,14 @@ public class ComplexUtils {
             c = new Complex[width / 2][height];
             for (int x = 0; x < width / 2; x++) {
                 for (int y = 0; y < height; y++) {
-                    c[x][y] = new Complex(d[x * 2][y], d[x * 2 + 1][y]);
+                    c[x][y] = Complex.ofCartesian(d[x * 2][y], d[x * 2 + 1][y]);
                 }
             }
         } else {
             c = new Complex[width][height / 2];
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height / 2; y++) {
-                    c[x][y] = new Complex(d[x][y * 2], d[x][y * 2 + 1]);
+                    c[x][y] = Complex.ofCartesian(d[x][y * 2], d[x][y * 2 + 1]);
                 }
             }
         }
@@ -1870,7 +1870,7 @@ public class ComplexUtils {
             for (int x = 0; x < width / 2; x++) {
                 for (int y = 0; y < height; y++) {
                     for (int z = 0; z < depth; z++) {
-                        c[x][y][z] = new Complex(d[x * 2][y][z], d[x * 2 + 1][y][z]);
+                        c[x][y][z] = Complex.ofCartesian(d[x * 2][y][z], d[x * 2 + 1][y][z]);
                     }
                 }
             }
@@ -1879,7 +1879,7 @@ public class ComplexUtils {
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height / 2; y++) {
                     for (int z = 0; z < depth; z++) {
-                        c[x][y][z] = new Complex(d[x][y * 2][z], d[x][y * 2 + 1][z]);
+                        c[x][y][z] = Complex.ofCartesian(d[x][y * 2][z], d[x][y * 2 + 1][z]);
                     }
                 }
             }
@@ -1888,7 +1888,7 @@ public class ComplexUtils {
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height; y++) {
                     for (int z = 0; z < depth / 2; z++) {
-                        c[x][y][z] = new Complex(d[x][y][z * 2], d[x][y][z * 2 + 1]);
+                        c[x][y][z] = Complex.ofCartesian(d[x][y][z * 2], d[x][y][z * 2 + 1]);
                     }
                 }
             }
@@ -1931,14 +1931,14 @@ public class ComplexUtils {
             c = new Complex[width / 2][height];
             for (int x = 0; x < width / 2; x++) {
                 for (int y = 0; y < height; y++) {
-                    c[x][y] = new Complex(d[x * 2][y], d[x * 2 + 1][y]);
+                    c[x][y] = Complex.ofCartesian(d[x * 2][y], d[x * 2 + 1][y]);
                 }
             }
         } else {
             c = new Complex[width][height / 2];
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height / 2; y++) {
-                    c[x][y] = new Complex(d[x][y * 2], d[x][y * 2 + 1]);
+                    c[x][y] = Complex.ofCartesian(d[x][y * 2], d[x][y * 2 + 1]);
                 }
             }
         }
@@ -1982,7 +1982,7 @@ public class ComplexUtils {
             for (int x = 0; x < width/2; x ++) {
                 for (int y = 0; y < height; y++) {
                     for (int z = 0; z < depth; z++) {
-                        c[x][y][z] = new Complex(d[x * 2][y][z], d[x * 2 + 1][y][z]);
+                        c[x][y][z] = Complex.ofCartesian(d[x * 2][y][z], d[x * 2 + 1][y][z]);
                     }
                 }
             }
@@ -1991,7 +1991,7 @@ public class ComplexUtils {
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height/2; y ++) {
                     for (int z = 0; z < depth; z++) {
-                        c[x][y][z] = new Complex(d[x][y * 2][z], d[x][y * 2 + 1][z]);
+                        c[x][y][z] = Complex.ofCartesian(d[x][y * 2][z], d[x][y * 2 + 1][z]);
                     }
                 }
             }
@@ -2000,7 +2000,7 @@ public class ComplexUtils {
             for (int x = 0; x < width; x++) {
                 for (int y = 0; y < height; y++) {
                     for (int z = 0; z < depth/2; z++) {
-                        c[x][y][z] = new Complex(d[x][y][z * 2], d[x][y][z * 2 + 1]);
+                        c[x][y][z] = Complex.ofCartesian(d[x][y][z * 2], d[x][y][z * 2 + 1]);
                     }
                 }
             }
@@ -2038,7 +2038,7 @@ public class ComplexUtils {
         final int length = real.length;
         final Complex[] c = new Complex[length];
         for (int n = 0; n < length; n++) {
-            c[n] = new Complex(real[n], imag[n]);
+            c[n] = Complex.ofCartesian(real[n], imag[n]);
         }
         return c;
     }
@@ -2095,7 +2095,7 @@ public class ComplexUtils {
         final int length = real.length;
         final Complex[] c = new Complex[length];
         for (int n = 0; n < length; n++) {
-            c[n] = new Complex(real[n], imag[n]);
+            c[n] = Complex.ofCartesian(real[n], imag[n]);
         }
         return c;
     }

--- a/src/main/java/org/apache/commons/math4/linear/EigenDecomposition.java
+++ b/src/main/java/org/apache/commons/math4/linear/EigenDecomposition.java
@@ -754,7 +754,7 @@ public class EigenDecomposition {
      */
     private Complex cdiv(final double xr, final double xi,
                          final double yr, final double yi) {
-        return new Complex(xr, xi).divide(new Complex(yr, yi));
+        return Complex.ofCartesian(xr, xi).divide(Complex.ofCartesian(yr, yi));
     }
 
     /**

--- a/src/main/java/org/apache/commons/math4/transform/TransformUtils.java
+++ b/src/main/java/org/apache/commons/math4/transform/TransformUtils.java
@@ -75,7 +75,7 @@ public class TransformUtils {
     public static Complex[] scaleArray(Complex[] f, double d) {
 
         for (int i = 0; i < f.length; i++) {
-            f[i] = new Complex(d * f[i].getReal(), d * f[i].getImaginary());
+            f[i] = Complex.ofCartesian(d * f[i].getReal(), d * f[i].getImaginary());
         }
         return f;
     }
@@ -135,7 +135,7 @@ public class TransformUtils {
         final int n = dataR.length;
         final Complex[] c = new Complex[n];
         for (int i = 0; i < n; i++) {
-            c[i] = new Complex(dataR[i], dataI[i]);
+            c[i] = Complex.ofCartesian(dataR[i], dataI[i]);
         }
         return c;
     }

--- a/src/test/java/org/apache/commons/math4/analysis/solvers/LaguerreSolverTest.java
+++ b/src/test/java/org/apache/commons/math4/analysis/solvers/LaguerreSolverTest.java
@@ -123,11 +123,11 @@ public final class LaguerreSolverTest {
         final LaguerreSolver solver = new LaguerreSolver();
         final Complex[] result = solver.solveAllComplex(coefficients, 0);
 
-        for (Complex expected : new Complex[] { new Complex(0, -2),
-                                                new Complex(0, 2),
-                                                new Complex(0.5, 0.5 * FastMath.sqrt(3)),
-                                                new Complex(-1, 0),
-                                                new Complex(0.5, -0.5 * FastMath.sqrt(3.0)) }) {
+        for (Complex expected : new Complex[] { Complex.ofCartesian(0, -2),
+                                                Complex.ofCartesian(0, 2),
+                                                Complex.ofCartesian(0.5, 0.5 * FastMath.sqrt(3)),
+                                                Complex.ofCartesian(-1, 0),
+                                                Complex.ofCartesian(0.5, -0.5 * FastMath.sqrt(3.0)) }) {
             final double tolerance = FastMath.max(solver.getAbsoluteAccuracy(),
                                                   FastMath.abs(expected.abs() * solver.getRelativeAccuracy()));
             TestUtils.assertContains(result, expected, tolerance);

--- a/src/test/java/org/apache/commons/math4/complex/ComplexFormatAbstractTest.java
+++ b/src/test/java/org/apache/commons/math4/complex/ComplexFormatAbstractTest.java
@@ -46,7 +46,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testSimpleNoDecimals() {
-        Complex c = new Complex(1, 2);
+        Complex c = Complex.ofCartesian(1, 2);
         String expected = "1 + 2i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -57,22 +57,22 @@ public abstract class ComplexFormatAbstractTest {
         final ComplexFormat fmt = ComplexFormat.getInstance(getLocale());
         fmt.getImaginaryFormat().setMaximumFractionDigits(1);
 
-        Complex c = new Complex(1, 1.04);
+        Complex c = Complex.ofCartesian(1, 1.04);
         String expected = "1 + i";
         String actual = fmt.format(c);
         Assert.assertEquals(expected, actual);
 
-        c = new Complex(1, 1.09);
+        c = Complex.ofCartesian(1, 1.09);
         expected = "1 + 1" + getDecimalCharacter() + "1i";
         actual = fmt.format(c);
         Assert.assertEquals(expected, actual);
 
-        c = new Complex(1, -1.09);
+        c = Complex.ofCartesian(1, -1.09);
         expected = "1 - 1" + getDecimalCharacter() + "1i";
         actual = fmt.format(c);
         Assert.assertEquals(expected, actual);
 
-        c = new Complex(1, -1.04);
+        c = Complex.ofCartesian(1, -1.04);
         expected = "1 - i";
         actual = fmt.format(c);
         Assert.assertEquals(expected, actual);
@@ -80,7 +80,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testSimpleWithDecimals() {
-        Complex c = new Complex(1.23, 1.43);
+        Complex c = Complex.ofCartesian(1.23, 1.43);
         String expected = "1" + getDecimalCharacter() + "23 + 1" + getDecimalCharacter() + "43i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -88,7 +88,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testSimpleWithDecimalsTrunc() {
-        Complex c = new Complex(1.232323232323, 1.434343434343);
+        Complex c = Complex.ofCartesian(1.232323232323, 1.434343434343);
         String expected = "1" + getDecimalCharacter() + "2323232323 + 1" + getDecimalCharacter() + "4343434343i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -96,7 +96,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testNegativeReal() {
-        Complex c = new Complex(-1.232323232323, 1.43);
+        Complex c = Complex.ofCartesian(-1.232323232323, 1.43);
         String expected = "-1" + getDecimalCharacter() + "2323232323 + 1" + getDecimalCharacter() + "43i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -104,7 +104,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testNegativeImaginary() {
-        Complex c = new Complex(1.23, -1.434343434343);
+        Complex c = Complex.ofCartesian(1.23, -1.434343434343);
         String expected = "1" + getDecimalCharacter() + "23 - 1" + getDecimalCharacter() + "4343434343i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -112,7 +112,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testNegativeBoth() {
-        Complex c = new Complex(-1.232323232323, -1.434343434343);
+        Complex c = Complex.ofCartesian(-1.232323232323, -1.434343434343);
         String expected = "-1" + getDecimalCharacter() + "2323232323 - 1" + getDecimalCharacter() + "4343434343i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -120,7 +120,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testZeroReal() {
-        Complex c = new Complex(0.0, -1.434343434343);
+        Complex c = Complex.ofCartesian(0.0, -1.434343434343);
         String expected = "0 - 1" + getDecimalCharacter() + "4343434343i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -128,7 +128,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testZeroImaginary() {
-        Complex c = new Complex(30.23333333333, 0);
+        Complex c = Complex.ofCartesian(30.23333333333, 0);
         String expected = "30" + getDecimalCharacter() + "2333333333";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -136,7 +136,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testDifferentImaginaryChar() {
-        Complex c = new Complex(1, 1);
+        Complex c = Complex.ofCartesian(1, 1);
         String expected = "1 + j";
         String actual = complexFormatJ.format(c);
         Assert.assertEquals(expected, actual);
@@ -147,7 +147,7 @@ public abstract class ComplexFormatAbstractTest {
         Locale defaultLocal = Locale.getDefault();
         Locale.setDefault(getLocale());
 
-        Complex c = new Complex(232.22222222222, -342.3333333333);
+        Complex c = Complex.ofCartesian(232.22222222222, -342.3333333333);
         String expected = "232" + getDecimalCharacter() + "2222222222 - 342" + getDecimalCharacter() + "3333333333i";
         String actual = (new ComplexFormat()).format(c);
         Assert.assertEquals(expected, actual);
@@ -157,7 +157,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testNan() {
-        Complex c = new Complex(Double.NaN, Double.NaN);
+        Complex c = Complex.ofCartesian(Double.NaN, Double.NaN);
         String expected = "(NaN) + (NaN)i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -165,7 +165,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testPositiveInfinity() {
-        Complex c = new Complex(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+        Complex c = Complex.ofCartesian(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
         String expected = "(Infinity) + (Infinity)i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -173,7 +173,7 @@ public abstract class ComplexFormatAbstractTest {
 
     @Test
     public void testNegativeInfinity() {
-        Complex c = new Complex(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
+        Complex c = Complex.ofCartesian(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
         String expected = "(-Infinity) - (Infinity)i";
         String actual = complexFormat.format(c);
         Assert.assertEquals(expected, actual);
@@ -182,7 +182,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseSimpleNoDecimals() {
         String source = "1 + 1i";
-        Complex expected = new Complex(1, 1);
+        Complex expected = Complex.ofCartesian(1, 1);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -190,7 +190,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseSimpleWithDecimals() {
         String source = "1" + getDecimalCharacter() + "23 + 1" + getDecimalCharacter() + "43i";
-        Complex expected = new Complex(1.23, 1.43);
+        Complex expected = Complex.ofCartesian(1.23, 1.43);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -198,7 +198,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseSimpleWithDecimalsTrunc() {
         String source = "1" + getDecimalCharacter() + "232323232323 + 1" + getDecimalCharacter() + "434343434343i";
-        Complex expected = new Complex(1.232323232323, 1.434343434343);
+        Complex expected = Complex.ofCartesian(1.232323232323, 1.434343434343);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -206,7 +206,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseNegativeReal() {
         String source = "-1" + getDecimalCharacter() + "232323232323 + 1" + getDecimalCharacter() + "4343i";
-        Complex expected = new Complex(-1.232323232323, 1.4343);
+        Complex expected = Complex.ofCartesian(-1.232323232323, 1.4343);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -214,7 +214,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseNegativeImaginary() {
         String source = "1" + getDecimalCharacter() + "2323 - 1" + getDecimalCharacter() + "434343434343i";
-        Complex expected = new Complex(1.2323, -1.434343434343);
+        Complex expected = Complex.ofCartesian(1.2323, -1.434343434343);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -222,7 +222,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseNegativeBoth() {
         String source = "-1" + getDecimalCharacter() + "232323232323 - 1" + getDecimalCharacter() + "434343434343i";
-        Complex expected = new Complex(-1.232323232323, -1.434343434343);
+        Complex expected = Complex.ofCartesian(-1.232323232323, -1.434343434343);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -230,7 +230,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseZeroReal() {
         String source = "0" + getDecimalCharacter() + "0 - 1" + getDecimalCharacter() + "4343i";
-        Complex expected = new Complex(0.0, -1.4343);
+        Complex expected = Complex.ofCartesian(0.0, -1.4343);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -238,7 +238,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseZeroImaginary() {
         String source = "-1" + getDecimalCharacter() + "2323";
-        Complex expected = new Complex(-1.2323, 0);
+        Complex expected = Complex.ofCartesian(-1.2323, 0);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -246,7 +246,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseDifferentImaginaryChar() {
         String source = "-1" + getDecimalCharacter() + "2323 - 1" + getDecimalCharacter() + "4343j";
-        Complex expected = new Complex(-1.2323, -1.4343);
+        Complex expected = Complex.ofCartesian(-1.2323, -1.4343);
         Complex actual = complexFormatJ.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -254,7 +254,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParseNan() {
         String source = "(NaN) + (NaN)i";
-        Complex expected = new Complex(Double.NaN, Double.NaN);
+        Complex expected = Complex.ofCartesian(Double.NaN, Double.NaN);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -262,7 +262,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testParsePositiveInfinity() {
         String source = "(Infinity) + (Infinity)i";
-        Complex expected = new Complex(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+        Complex expected = Complex.ofCartesian(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -270,7 +270,7 @@ public abstract class ComplexFormatAbstractTest {
     @Test
     public void testPaseNegativeInfinity() {
         String source = "(-Infinity) - (Infinity)i";
-        Complex expected = new Complex(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
+        Complex expected = Complex.ofCartesian(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
         Complex actual = complexFormat.parse(source);
         Assert.assertEquals(expected, actual);
     }
@@ -356,7 +356,7 @@ public abstract class ComplexFormatAbstractTest {
     public void testFormatObjectStringBufferFieldPositionWithComplex() {
         ComplexFormat cf = ComplexFormat.getInstance(getLocale());
         String source = "1" + getDecimalCharacter() + "23 + 1" + getDecimalCharacter() + "43i";
-        Object expected = new Complex(1.23, 1.43);
+        Object expected = Complex.ofCartesian(1.23, 1.43);
         String formatted = cf.format(expected, new StringBuffer(), new FieldPosition(0)).toString();
         Assert.assertEquals(source, formatted);
     }

--- a/src/test/java/org/apache/commons/math4/complex/ComplexUtilsTest.java
+++ b/src/test/java/org/apache/commons/math4/complex/ComplexUtilsTest.java
@@ -35,11 +35,11 @@ public class ComplexUtilsTest {
     private final double nan = Double.NaN;
     private final double pi = FastMath.PI;
 
-    private final Complex negInfInf = new Complex(negInf, inf);
-    private final Complex infNegInf = new Complex(inf, negInf);
-    private final Complex infInf = new Complex(inf, inf);
-    private final Complex negInfNegInf = new Complex(negInf, negInf);
-    private final Complex infNaN = new Complex(inf, nan);
+    private final Complex negInfInf = Complex.ofCartesian(negInf, inf);
+    private final Complex infNegInf = Complex.ofCartesian(inf, negInf);
+    private final Complex infInf = Complex.ofCartesian(inf, inf);
+    private final Complex negInfNegInf = Complex.ofCartesian(negInf, negInf);
+    private final Complex infNaN = Complex.ofCartesian(inf, nan);
 
     private static Complex c[]; // complex array with real values even and imag
                                 // values odd
@@ -116,9 +116,9 @@ public class ComplexUtilsTest {
             di[i + 1] = i + 1;
             fi[i] = i;
             fi[i + 1] = i + 1;
-            c[i / 2] = new Complex(i, i + 1);
-            cr[i / 2] = new Complex(i / 2);
-            ci[i / 2] = new Complex(0, i / 2);
+            c[i / 2] = Complex.ofCartesian(i, i + 1);
+            cr[i / 2] = Complex.ofCartesian(i / 2);
+            ci[i / 2] = Complex.ofCartesian(0, i / 2);
             sr[i / 2] = i;
             si[i / 2] = i + 1;
             sfr[i / 2] = i;
@@ -136,9 +136,9 @@ public class ComplexUtilsTest {
                 di2d[i][j + 1] = 10 * i + j + 1;
                 fi2d[i][j] = 10 * i + j;
                 fi2d[i][j + 1] = 10 * i + j + 1;
-                c2d[i][j / 2] = new Complex(10 * i + j, 10 * i + j + 1);
-                cr2d[i][j / 2] = new Complex(10 * i + j / 2);
-                ci2d[i][j / 2] = new Complex(0, 10 * i + j / 2);
+                c2d[i][j / 2] = Complex.ofCartesian(10 * i + j, 10 * i + j + 1);
+                cr2d[i][j / 2] = Complex.ofCartesian(10 * i + j / 2);
+                ci2d[i][j / 2] = Complex.ofCartesian(0, 10 * i + j / 2);
             }
         }
         for (int i = 0; i < 10; i++) {
@@ -154,20 +154,20 @@ public class ComplexUtilsTest {
                     di3d[i][j][k + 1] = 100 * i + 10 * j + k + 1;
                     fi3d[i][j][k] = 100 * i + 10 * j + k;
                     fi3d[i][j][k + 1] = 100 * i + 10 * j + k + 1;
-                    c3d[i][j][k / 2] = new Complex(100 * i + 10 * j + k, 100 * i + 10 * j + k + 1);
-                    cr3d[i][j][k / 2] = new Complex(100 * i + 10 * j + k / 2);
-                    ci3d[i][j][k / 2] = new Complex(0, 100 * i + 10 * j + k / 2);
+                    c3d[i][j][k / 2] = Complex.ofCartesian(100 * i + 10 * j + k, 100 * i + 10 * j + k + 1);
+                    cr3d[i][j][k / 2] = Complex.ofCartesian(100 * i + 10 * j + k / 2);
+                    ci3d[i][j][k / 2] = Complex.ofCartesian(0, 100 * i + 10 * j + k / 2);
                 }
             }
         }
-        ansArrayc1r = new Complex[] { new Complex(3), new Complex(4), new Complex(5), new Complex(6), new Complex(7) };
-        ansArrayc2r = new Complex[] { new Complex(3), new Complex(5), new Complex(7) };
-        ansArrayc1i = new Complex[] { new Complex(0, 3), new Complex(0, 4), new Complex(0, 5), new Complex(0, 6),
-                new Complex(0, 7) };
-        ansArrayc2i = new Complex[] { new Complex(0, 3), new Complex(0, 5), new Complex(0, 7) };
-        ansArrayc3 = new Complex[] { new Complex(6, 7), new Complex(8, 9), new Complex(10, 11), new Complex(12, 13),
-                new Complex(14, 15) };
-        ansArrayc4 = new Complex[] { new Complex(6, 7), new Complex(10, 11), new Complex(14, 15) };
+        ansArrayc1r = new Complex[] { Complex.ofCartesian(3), Complex.ofCartesian(4), Complex.ofCartesian(5), Complex.ofCartesian(6), Complex.ofCartesian(7) };
+        ansArrayc2r = new Complex[] { Complex.ofCartesian(3), Complex.ofCartesian(5), Complex.ofCartesian(7) };
+        ansArrayc1i = new Complex[] { Complex.ofCartesian(0, 3), Complex.ofCartesian(0, 4), Complex.ofCartesian(0, 5), Complex.ofCartesian(0, 6),
+                Complex.ofCartesian(0, 7) };
+        ansArrayc2i = new Complex[] { Complex.ofCartesian(0, 3), Complex.ofCartesian(0, 5), Complex.ofCartesian(0, 7) };
+        ansArrayc3 = new Complex[] { Complex.ofCartesian(6, 7), Complex.ofCartesian(8, 9), Complex.ofCartesian(10, 11), Complex.ofCartesian(12, 13),
+                Complex.ofCartesian(14, 15) };
+        ansArrayc4 = new Complex[] { Complex.ofCartesian(6, 7), Complex.ofCartesian(10, 11), Complex.ofCartesian(14, 15) };
         ansArrayd1r = new double[] { 6, 8, 10, 12, 14 };
         ansArrayd1i = new double[] { 7, 9, 11, 13, 15 };
         ansArrayd2r = new double[] { 6, 10, 14 };
@@ -207,7 +207,7 @@ public class ComplexUtilsTest {
     }
 
     protected Complex altPolar(double r, double theta) {
-        return Complex.I.multiply(new Complex(theta, 0)).exp().multiply(new Complex(r, 0));
+        return Complex.I.multiply(Complex.ofCartesian(theta, 0)).exp().multiply(Complex.ofCartesian(r, 0));
     }
 
     @Test(expected = MathIllegalArgumentException.class)
@@ -251,17 +251,17 @@ public class ComplexUtilsTest {
     public void testExtractionMethods() {
         setArrays();
         // Extract complex from real double array, index 3
-        TestUtils.assertSame(new Complex(3), ComplexUtils.extractComplexFromRealArray(d, 3));
+        TestUtils.assertSame(Complex.ofCartesian(3), ComplexUtils.extractComplexFromRealArray(d, 3));
         // Extract complex from real float array, index 3
-        TestUtils.assertSame(new Complex(3), ComplexUtils.extractComplexFromRealArray(f, 3));
+        TestUtils.assertSame(Complex.ofCartesian(3), ComplexUtils.extractComplexFromRealArray(f, 3));
         // Extract real double from complex array, index 3
         TestUtils.assertSame(6, ComplexUtils.extractRealFromComplexArray(c, 3));
         // Extract real float from complex array, index 3
         TestUtils.assertSame(6, ComplexUtils.extractRealFloatFromComplexArray(c, 3));
         // Extract complex from interleaved double array, index 3
-        TestUtils.assertSame(new Complex(6, 7), ComplexUtils.extractComplexFromInterleavedArray(d, 3));
+        TestUtils.assertSame(Complex.ofCartesian(6, 7), ComplexUtils.extractComplexFromInterleavedArray(d, 3));
         // Extract complex from interleaved float array, index 3
-        TestUtils.assertSame(new Complex(6, 7), ComplexUtils.extractComplexFromInterleavedArray(f, 3));
+        TestUtils.assertSame(Complex.ofCartesian(6, 7), ComplexUtils.extractComplexFromInterleavedArray(f, 3));
         // Extract interleaved double from complex array, index 3
         TestUtils.assertEquals(msg, new double[] { 6, 7 }, ComplexUtils.extractInterleavedFromComplexArray(c, 3),
                 Math.ulp(1));
@@ -593,7 +593,7 @@ public class ComplexUtilsTest {
         Complex[] c = new Complex[10];
         ComplexUtils.initialize(c);
         for (Complex cc : c) {
-            TestUtils.assertEquals(new Complex(0, 0), cc, 0);
+            TestUtils.assertEquals(Complex.ofCartesian(0, 0), cc, 0);
         }
     }
 }

--- a/src/test/java/org/apache/commons/math4/transform/FastFourierTransformerTest.java
+++ b/src/test/java/org/apache/commons/math4/transform/FastFourierTransformerTest.java
@@ -174,7 +174,7 @@ public final class FastFourierTransformerTest {
         for (int i = 0; i < n; i++) {
             final double re = 2.0 * random.nextDouble() - 1.0;
             final double im = 2.0 * random.nextDouble() - 1.0;
-            data[i] = new Complex(re, im);
+            data[i] = Complex.ofCartesian(re, im);
         }
         return data;
     }
@@ -211,7 +211,7 @@ public final class FastFourierTransformerTest {
                 yr += c * xr - sgn * s * xi;
                 yi += sgn * s * xr + c * xi;
             }
-            y[i] = new Complex(yr, yi);
+            y[i] = Complex.ofCartesian(yr, yi);
         }
         return y;
     }
@@ -260,7 +260,7 @@ public final class FastFourierTransformerTest {
         final double[] x = createRealData(n);
         final Complex[] xc = new Complex[n];
         for (int i = 0; i < n; i++) {
-            xc[i] = new Complex(x[i], 0.0);
+            xc[i] = Complex.ofCartesian(x[i], 0.0);
         }
         final Complex[] expected;
         final double s;
@@ -301,7 +301,7 @@ public final class FastFourierTransformerTest {
         final Complex[] x = new Complex[n];
         for (int i = 0; i < n; i++) {
             final double t = min + i * (max - min) / n;
-            x[i] = new Complex(f.value(t));
+            x[i] = Complex.ofCartesian(f.value(t));
         }
         final Complex[] expected;
         final double s;
@@ -411,14 +411,14 @@ public final class FastFourierTransformerTest {
 
         double x[] = {1.3, 2.4, 1.7, 4.1, 2.9, 1.7, 5.1, 2.7};
         Complex y[] = {
-            new Complex(21.9, 0.0),
-            new Complex(-2.09497474683058, 1.91507575950825),
-            new Complex(-2.6, 2.7),
-            new Complex(-1.10502525316942, -4.88492424049175),
-            new Complex(0.1, 0.0),
-            new Complex(-1.10502525316942, 4.88492424049175),
-            new Complex(-2.6, -2.7),
-            new Complex(-2.09497474683058, -1.91507575950825)};
+            Complex.ofCartesian(21.9, 0.0),
+            Complex.ofCartesian(-2.09497474683058, 1.91507575950825),
+            Complex.ofCartesian(-2.6, 2.7),
+            Complex.ofCartesian(-1.10502525316942, -4.88492424049175),
+            Complex.ofCartesian(0.1, 0.0),
+            Complex.ofCartesian(-1.10502525316942, 4.88492424049175),
+            Complex.ofCartesian(-2.6, -2.7),
+            Complex.ofCartesian(-2.09497474683058, -1.91507575950825)};
 
         result = transformer.transform(x, TransformType.FORWARD);
         for (int i = 0; i < result.length; i++) {


### PR DESCRIPTION
Replace all calls to the old o.a.c.numbers.Complex constructor with calls to the new static factory methods (eg, Complex.ofCartesian()). The build fails without this since the Complex constructor is now private.