### PR TITLE
Flush ObjectOutputStream before calling toByteArray on underlying ByteArrayOutputStream

### DIFF
--- a/src/test/java/org/apache/commons/math4/TestUtils.java
+++ b/src/test/java/org/apache/commons/math4/TestUtils.java
@@ -113,6 +113,7 @@ public class TestUtils {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             ObjectOutputStream so = new ObjectOutputStream(bos);
             so.writeObject(o);
+            so.flush();
 
             // deserialize the Object
             ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());

--- a/src/test/java/org/apache/commons/math4/distribution/RealDistributionAbstractTest.java
+++ b/src/test/java/org/apache/commons/math4/distribution/RealDistributionAbstractTest.java
@@ -506,6 +506,7 @@ public abstract class RealDistributionAbstractTest {
         final ByteArrayOutputStream bOut = new ByteArrayOutputStream();
         final ObjectOutputStream oOut = new ObjectOutputStream(bOut);
         oOut.writeObject(distribution);
+        oOut.flush();
         final byte[] data = bOut.toByteArray();
 
         // Deserialize from byte array.

--- a/src/test/java/org/apache/commons/math4/exception/util/ExceptionContextTest.java
+++ b/src/test/java/org/apache/commons/math4/exception/util/ExceptionContextTest.java
@@ -90,6 +90,7 @@ public class ExceptionContextTest {
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(bos);
         oos.writeObject(cOut);
+        oos.flush();
 
         ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
         ObjectInputStream ois = new ObjectInputStream(bis);
@@ -113,6 +114,7 @@ public class ExceptionContextTest {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             ObjectOutputStream oos = new ObjectOutputStream(bos);
             oos.writeObject(cOut);
+            oos.flush();
 
             ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
             ObjectInputStream ois = new ObjectInputStream(bis);

--- a/src/test/java/org/apache/commons/math4/ml/neuralnet/NetworkTest.java
+++ b/src/test/java/org/apache/commons/math4/ml/neuralnet/NetworkTest.java
@@ -186,6 +186,7 @@ public class NetworkTest {
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(bos);
         oos.writeObject(out);
+        oos.flush();
 
         final ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
         final ObjectInputStream ois = new ObjectInputStream(bis);

--- a/src/test/java/org/apache/commons/math4/ml/neuralnet/NeuronTest.java
+++ b/src/test/java/org/apache/commons/math4/ml/neuralnet/NeuronTest.java
@@ -121,6 +121,7 @@ public class NeuronTest {
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(bos);
         oos.writeObject(out);
+        oos.flush();
 
         final ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
         final ObjectInputStream ois = new ObjectInputStream(bis);

--- a/src/test/java/org/apache/commons/math4/ml/neuralnet/oned/NeuronStringTest.java
+++ b/src/test/java/org/apache/commons/math4/ml/neuralnet/oned/NeuronStringTest.java
@@ -157,6 +157,7 @@ public class NeuronStringTest {
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(bos);
         oos.writeObject(out);
+        oos.flush();
 
         final ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
         final ObjectInputStream ois = new ObjectInputStream(bis);

--- a/src/test/java/org/apache/commons/math4/ml/neuralnet/twod/NeuronSquareMesh2DTest.java
+++ b/src/test/java/org/apache/commons/math4/ml/neuralnet/twod/NeuronSquareMesh2DTest.java
@@ -659,6 +659,7 @@ public class NeuronSquareMesh2DTest {
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(bos);
         oos.writeObject(out);
+        oos.flush();
 
         final ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());
         final ObjectInputStream ois = new ObjectInputStream(bis);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/ClassicalRungeKuttaStepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/ClassicalRungeKuttaStepInterpolatorTest.java
@@ -68,6 +68,7 @@ public class ClassicalRungeKuttaStepInterpolatorTest {
     for (StepHandler handler : integ.getStepHandlers()) {
         oos.writeObject(handler);
     }
+    oos.flush();
 
     Assert.assertTrue(bos.size () > 880000);
     Assert.assertTrue(bos.size () < 900000);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/DormandPrince54StepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/DormandPrince54StepInterpolatorTest.java
@@ -80,6 +80,7 @@ public class DormandPrince54StepInterpolatorTest {
     for (StepHandler handler : integ.getStepHandlers()) {
         oos.writeObject(handler);
     }
+    oos.flush();
 
     Assert.assertTrue(bos.size () > 135000);
     Assert.assertTrue(bos.size () < 145000);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/DormandPrince853StepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/DormandPrince853StepInterpolatorTest.java
@@ -80,6 +80,7 @@ public class DormandPrince853StepInterpolatorTest {
     for (StepHandler handler : integ.getStepHandlers()) {
         oos.writeObject(handler);
     }
+    oos.flush();
 
     Assert.assertTrue(bos.size () > 90000);
     Assert.assertTrue(bos.size () < 100000);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/EulerStepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/EulerStepInterpolatorTest.java
@@ -162,6 +162,7 @@ public class EulerStepInterpolatorTest {
     for (StepHandler handler : integ.getStepHandlers()) {
         oos.writeObject(handler);
     }
+    oos.flush();
 
     ByteArrayInputStream  bis = new ByteArrayInputStream(bos.toByteArray());
     ObjectInputStream     ois = new ObjectInputStream(bis);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/GillStepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/GillStepInterpolatorTest.java
@@ -68,6 +68,7 @@ public class GillStepInterpolatorTest {
     for (StepHandler handler : integ.getStepHandlers()) {
         oos.writeObject(handler);
     }
+    oos.flush();
 
     Assert.assertTrue(bos.size () > 880000);
     Assert.assertTrue(bos.size () < 900000);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/GraggBulirschStoerStepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/GraggBulirschStoerStepInterpolatorTest.java
@@ -82,6 +82,7 @@ public class GraggBulirschStoerStepInterpolatorTest {
     for (StepHandler handler : integ.getStepHandlers()) {
         oos.writeObject(handler);
     }
+    oos.flush();
 
     Assert.assertTrue(bos.size () > 35000);
     Assert.assertTrue(bos.size () < 36000);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/HighamHall54StepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/HighamHall54StepInterpolatorTest.java
@@ -80,6 +80,7 @@ public class HighamHall54StepInterpolatorTest {
     for (StepHandler handler : integ.getStepHandlers()) {
         oos.writeObject(handler);
     }
+    oos.flush();
 
     Assert.assertTrue(bos.size () > 185000);
     Assert.assertTrue(bos.size () < 195000);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/LutherStepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/LutherStepInterpolatorTest.java
@@ -68,6 +68,7 @@ public class LutherStepInterpolatorTest {
         for (StepHandler handler : integ.getStepHandlers()) {
             oos.writeObject(handler);
         }
+        oos.flush();
 
         Assert.assertTrue(bos.size() > 1200000);
         Assert.assertTrue(bos.size() < 1250000);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/MidpointStepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/MidpointStepInterpolatorTest.java
@@ -69,6 +69,7 @@ public class MidpointStepInterpolatorTest {
     for (StepHandler handler : integ.getStepHandlers()) {
         oos.writeObject(handler);
     }
+    oos.flush();
 
     Assert.assertTrue(bos.size () > 135000);
     Assert.assertTrue(bos.size () < 145000);

--- a/src/test/java/org/apache/commons/math4/ode/nonstiff/ThreeEighthesStepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/nonstiff/ThreeEighthesStepInterpolatorTest.java
@@ -68,6 +68,7 @@ public class ThreeEighthesStepInterpolatorTest {
     for (StepHandler handler : integ.getStepHandlers()) {
         oos.writeObject(handler);
     }
+    oos.flush();
 
     Assert.assertTrue(bos.size () > 880000);
     Assert.assertTrue(bos.size () < 900000);

--- a/src/test/java/org/apache/commons/math4/ode/sampling/DummyStepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/sampling/DummyStepInterpolatorTest.java
@@ -84,6 +84,7 @@ public class DummyStepInterpolatorTest {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     ObjectOutputStream    oos = new ObjectOutputStream(bos);
     oos.writeObject(interpolator);
+    oos.flush();
 
     Assert.assertTrue(bos.size () > 300);
     Assert.assertTrue(bos.size () < 500);

--- a/src/test/java/org/apache/commons/math4/ode/sampling/NordsieckStepInterpolatorTest.java
+++ b/src/test/java/org/apache/commons/math4/ode/sampling/NordsieckStepInterpolatorTest.java
@@ -66,6 +66,7 @@ public class NordsieckStepInterpolatorTest {
         for (StepHandler handler : integ.getStepHandlers()) {
             oos.writeObject(handler);
         }
+        oos.flush();
 
         Assert.assertTrue(bos.size() > 47000);
         Assert.assertTrue(bos.size() < 48000);


### PR DESCRIPTION
When an `ObjectOutputStream` instance wraps an underlying `ByteArrayOutputStream` instance,
it is recommended to flush or close the `ObjectOutputStream` before invoking the underlying instances's `toByteArray()`.
Although in these cases it is not strictly necessary because `writeObject` method is invoked right before `toByteArray`, and `writeObject` internally calls `flush`/`drain`. However, it is good practice to call
`flush`/`close` explicitly as mentioned, for example, [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a call to the `flush` method before calls to the `toByteArray` method.