### PR TITLE
The TreeBuilder constructor does not check the validity of the input String s

### DIFF
--- a/src/test/java/org/apache/commons/math4/geometry/euclidean/threed/PolyhedronsSetTest.java
+++ b/src/test/java/org/apache/commons/math4/geometry/euclidean/threed/PolyhedronsSetTest.java
@@ -56,6 +56,16 @@ public class PolyhedronsSetTest {
 
     private static final double TEST_TOLERANCE = 1e-10;
 
+    @Test(expected = ParseException.class)
+    public void testWithEmptyString() throws IOException, ParseException {
+        PolyhedronsSet polySet = RegionParser.parsePolyhedronsSet("");
+    }
+
+    @Test(expected = ParseException.class)
+    public void testWithNullString() throws IOException, ParseException {
+        PolyhedronsSet polySet = RegionParser.parsePolyhedronsSet(null);
+    }
+
     @Test
     public void testWholeSpace() {
         // act

--- a/src/test/java/org/apache/commons/math4/geometry/partitioning/RegionParser.java
+++ b/src/test/java/org/apache/commons/math4/geometry/partitioning/RegionParser.java
@@ -205,6 +205,9 @@ public class RegionParser {
          */
         public TreeBuilder(final String type, final String s)
             throws IOException, ParseException {
+            if (s == null || s.isEmpty()) {
+                throw new ParseException("the string cannot be null or empty", 0);
+            }
             root = null;
             tokenizer = new StringTokenizer(s);
             getWord(type);


### PR DESCRIPTION
The `TreeBuilder` constructor does not check whether the input string `s` is null before constructing
a `StringTokenizer`. This will cause a `NullPointerException` to be thrown according to the [docs](https://docs.oracle.com/javase/7/docs/api/java/util/StringTokenizer.html#StringTokenizer(java.lang.String)).
It also does not check whether `s` is empty. This will cause a NoSuchElementException to be thrown when nextToken() is called according to the [docs](https://docs.oracle.com/javase/7/docs/api/java/util/StringTokenizer.html#nextToken()).

This pull request adds a check to the String `s` and throws a ParseException if `s` is null or empty. It also adds two tests.