### PR TITLE
MATH-1486: Add Automatic-Module-Name to MANIFEST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,7 @@
          (see "commons.osgi.symbolicName", below). -->
     <commons.componentid>math</commons.componentid>
     <!-- This value must reflect the current name of the base package. -->
+    <commons.module.name>org.apache.commons.math3</commons.module.name>
     <commons.osgi.symbolicName>org.apache.commons.math3</commons.osgi.symbolicName>
     <!-- do not use snapshot suffix here -->
     <commons.release.version>3.6.2-SNAPSHOT</commons.release.version>
@@ -425,6 +426,23 @@
                 <exclude>**/*AbstractTest.java</exclude>
               </excludes>
           </configuration>
+        </plugin>
+        <!-- Add Java 9 module name to MANIFEST.MF, only for main jar, not test jar -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>default-jar</id>
+              <configuration>
+                <archive>
+                  <manifestEntries>
+                    <Automatic-Module-Name>${commons.module.name}</Automatic-Module-Name>
+                  </manifestEntries>
+                </archive>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <artifactId>maven-assembly-plugin</artifactId>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -51,6 +51,9 @@ If the output is not quite correct, check for invisible trailing spaces!
   </properties>
   <body>
     <release version="TBD" date="TBD" description="TBD">
+      <action dev="scolebourne" type="update" issue="MATH-1486">
+        Add 'Automatic-Module-Name' for Java 9 and later.
+      </action>
       <action dev="ebourg" type="update" issue="MATH-1389" due-to="Christoph Dibak">
         Performance improvement for Array2DRowRealMatrix.getSubMatrix()
       </action>


### PR DESCRIPTION
For Java 9 and later, [MATH-1486](https://issues.apache.org/jira/browse/MATH-1486)