### PR TITLE
MATH-1492: Replace usages of commons-numbers-core methods with equivalent java.lang.Math methods

### DIFF
--- a/src/main/java/org/apache/commons/math4/fraction/Fraction.java
+++ b/src/main/java/org/apache/commons/math4/fraction/Fraction.java
@@ -499,12 +499,12 @@ public class Fraction
         int d1 = ArithmeticUtils.gcd(denominator, fraction.denominator);
         if (d1==1) {
             // result is ( (u*v' +/- u'v) / u'v')
-            int uvp = ArithmeticUtils.mulAndCheck(numerator, fraction.denominator);
-            int upv = ArithmeticUtils.mulAndCheck(fraction.numerator, denominator);
+            int uvp = Math.multiplyExact(numerator, fraction.denominator);
+            int upv = Math.multiplyExact(fraction.numerator, denominator);
             return new Fraction
-                (isAdd ? ArithmeticUtils.addAndCheck(uvp, upv) :
-                 ArithmeticUtils.subAndCheck(uvp, upv),
-                 ArithmeticUtils.mulAndCheck(denominator, fraction.denominator));
+                (isAdd ? Math.addExact(uvp, upv) :
+                 Math.subtractExact(uvp, upv),
+                 Math.multiplyExact(denominator, fraction.denominator));
         }
         // the quantity 't' requires 65 bits of precision; see knuth 4.5.1
         // exercise 7.  we're going to use a BigInteger.
@@ -526,7 +526,7 @@ public class Fraction
                                               w);
         }
         return new Fraction (w.intValue(),
-                ArithmeticUtils.mulAndCheck(denominator/d1,
+                Math.multiplyExact(denominator/d1,
                         fraction.denominator/d2));
     }
 
@@ -553,8 +553,8 @@ public class Fraction
         int d1 = ArithmeticUtils.gcd(numerator, fraction.denominator);
         int d2 = ArithmeticUtils.gcd(fraction.numerator, denominator);
         return getReducedFraction
-        (ArithmeticUtils.mulAndCheck(numerator/d1, fraction.numerator/d2),
-                ArithmeticUtils.mulAndCheck(denominator/d2, fraction.denominator/d1));
+        (Math.multiplyExact(numerator/d1, fraction.numerator/d2),
+                Math.multiplyExact(denominator/d2, fraction.denominator/d1));
     }
 
     /**

--- a/src/test/java/org/apache/commons/math4/linear/InverseHilbertMatrix.java
+++ b/src/test/java/org/apache/commons/math4/linear/InverseHilbertMatrix.java
@@ -20,7 +20,6 @@ import org.apache.commons.math4.exception.DimensionMismatchException;
 import org.apache.commons.math4.linear.ArrayRealVector;
 import org.apache.commons.math4.linear.RealLinearOperator;
 import org.apache.commons.math4.linear.RealVector;
-import org.apache.commons.numbers.core.ArithmeticUtils;
 import org.apache.commons.numbers.combinatorics.BinomialCoefficient;
 
 /**
@@ -59,12 +58,12 @@ public class InverseHilbertMatrix
     public long getEntry(final int i, final int j) {
         long val = i + j + 1;
         long aux = BinomialCoefficient.value(n + i, n - j - 1);
-        val = ArithmeticUtils.mulAndCheck(val, aux);
+        val = Math.multiplyExact(val, aux);
         aux = BinomialCoefficient.value(n + j, n - i - 1);
-        val = ArithmeticUtils.mulAndCheck(val, aux);
+        val = Math.multiplyExact(val, aux);
         aux = BinomialCoefficient.value(i + j, i);
-        val = ArithmeticUtils.mulAndCheck(val, aux);
-        val = ArithmeticUtils.mulAndCheck(val, aux);
+        val = Math.multiplyExact(val, aux);
+        val = Math.multiplyExact(val, aux);
         return ((i + j) & 1) == 0 ? val : -val;
     }
 


### PR DESCRIPTION
Replace usages of the following methods from org.apache.commons.numbers.core.ArithmeticUtils:

addAndCheck(int, int)
addAndCheck(long, long)
mulAndCheck(int, int)
mulAndCheck(long, long)
subAndCheck(int, int)
subAndCheck(long, long)

With the following methods from java.lang.Math:

addExact(int, int)
addExact(long, long)
multiplyExact(int, int)
multiplyExact(long, long)
subtractExact(int, int)
subtractExact(long, long)