### PR TITLE
Close ObjectOutputStream before calling toByteArray on underlying ByteArrayOutputStream

### DIFF
--- a/src/test/java/org/apache/commons/math4/TestUtils.java
+++ b/src/test/java/org/apache/commons/math4/TestUtils.java
@@ -113,6 +113,7 @@ public class TestUtils {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
             ObjectOutputStream so = new ObjectOutputStream(bos);
             so.writeObject(o);
+            so.close();
 
             // deserialize the Object
             ByteArrayInputStream bis = new ByteArrayInputStream(bos.toByteArray());


### PR DESCRIPTION
When an `ObjectOutputStream` instance wraps an underlying `ByteArrayOutputStream` instance,
it is recommended to flush or close the `ObjectOutputStream` before invoking the underlying instances's `toByteArray()`. Although in these cases it is not strictly necessary because `writeObject` method is invoked right before `toByteArray`, and `writeObject` internally calls `flush`/`drain`. However, it is good practice to call `flush`/`close` explicitly as mentioned, for example, [here](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java).
This pull request adds a call to the `close` method before calls to the `toByteArray` methods.