### PR TITLE
Implement the MiniBatchKMeansClusterer

### DIFF
--- a/src/main/java/org/apache/commons/math4/ml/clustering/ClusterUtils.java
+++ b/src/main/java/org/apache/commons/math4/ml/clustering/ClusterUtils.java
@@ -1,0 +1,96 @@
+package org.apache.commons.math4.ml.clustering;
+
+import org.apache.commons.math4.exception.ConvergenceException;
+import org.apache.commons.math4.exception.util.LocalizedFormats;
+import org.apache.commons.math4.ml.distance.DistanceMeasure;
+import org.apache.commons.math4.stat.descriptive.moment.Variance;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class ClusterUtils {
+    private ClusterUtils() {
+    }
+
+    public static <T> ArrayList<T> shuffle(Collection<T> c, UniformRandomProvider random) {
+        ArrayList<T> list = new ArrayList<T>(c);
+        int size = list.size();
+        for (int i = size; i > 1; --i) {
+            list.set(i - 1, list.set(random.nextInt(i), list.get(i - 1)));
+        }
+        return list;
+    }
+
+    public static <T> ArrayList<T> shuffle(Collection<T> points) {
+        return shuffle(points, RandomSource.create(RandomSource.MT_64));
+    }
+
+    /**
+     * Computes the centroid for a set of points.
+     *
+     * @param points    the set of points
+     * @param dimension the point dimension
+     * @return the computed centroid for the set of points
+     */
+    public static <T extends Clusterable> Clusterable centroidOf(final Collection<T> points, final int dimension) {
+        final double[] centroid = new double[dimension];
+        for (final T p : points) {
+            final double[] point = p.getPoint();
+            for (int i = 0; i < centroid.length; i++) {
+                centroid[i] += point[i];
+            }
+        }
+        for (int i = 0; i < centroid.length; i++) {
+            centroid[i] /= points.size();
+        }
+        return new DoublePoint(centroid);
+    }
+
+
+    /**
+     * Get a random point from the {@link Cluster} with the largest distance variance.
+     *
+     * @param clusters the {@link Cluster}s to search
+     * @param measure  DistanceMeasure
+     * @param random   Random generator
+     * @return a random point from the selected cluster
+     * @throws ConvergenceException if clusters are all empty
+     */
+    public static <T extends Clusterable> T getPointFromLargestVarianceCluster(final Collection<CentroidCluster<T>> clusters,
+                                                                               final DistanceMeasure measure,
+                                                                               final UniformRandomProvider random)
+            throws ConvergenceException {
+        double maxVariance = Double.NEGATIVE_INFINITY;
+        Cluster<T> selected = null;
+        for (final CentroidCluster<T> cluster : clusters) {
+            if (!cluster.getPoints().isEmpty()) {
+                // compute the distance variance of the current cluster
+                final Clusterable center = cluster.getCenter();
+                final Variance stat = new Variance();
+                for (final T point : cluster.getPoints()) {
+                    stat.increment(measure.compute(point.getPoint(), center.getPoint()));
+                }
+                final double variance = stat.getResult();
+
+                // select the cluster with the largest variance
+                if (variance > maxVariance) {
+                    maxVariance = variance;
+                    selected = cluster;
+                }
+
+            }
+        }
+
+        // did we find at least one non-empty cluster ?
+        if (selected == null) {
+            throw new ConvergenceException(LocalizedFormats.EMPTY_CLUSTER_IN_K_MEANS);
+        }
+
+        // extract a random point from the cluster
+        final List<T> selectedPoints = selected.getPoints();
+        return selectedPoints.remove(random.nextInt(selectedPoints.size()));
+    }
+}

--- a/src/main/java/org/apache/commons/math4/ml/clustering/ClusterUtils.java
+++ b/src/main/java/org/apache/commons/math4/ml/clustering/ClusterUtils.java
@@ -3,29 +3,57 @@ package org.apache.commons.math4.ml.clustering;
 import org.apache.commons.math4.exception.ConvergenceException;
 import org.apache.commons.math4.exception.util.LocalizedFormats;
 import org.apache.commons.math4.ml.distance.DistanceMeasure;
+import org.apache.commons.math4.ml.distance.EuclideanDistance;
 import org.apache.commons.math4.stat.descriptive.moment.Variance;
 import org.apache.commons.rng.UniformRandomProvider;
-import org.apache.commons.rng.simple.RandomSource;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Common functions used in clustering
+ */
 public class ClusterUtils {
+    /**
+     * Use only for static
+     */
     private ClusterUtils() {
     }
 
-    public static <T> ArrayList<T> shuffle(Collection<T> c, UniformRandomProvider random) {
-        ArrayList<T> list = new ArrayList<T>(c);
-        int size = list.size();
-        for (int i = size; i > 1; --i) {
-            list.set(i - 1, list.set(random.nextInt(i), list.get(i - 1)));
+    public static final DistanceMeasure DEFAULT_MEASURE = new EuclideanDistance();
+
+    /**
+     * Predict which cluster is best for the point
+     *
+     * @param clusters cluster to predict into
+     * @param point    point to predict
+     * @param measure  distance measurer
+     * @param <T>      type of cluster point
+     * @return the cluster which has nearest center to the point
+     */
+    public static <T extends Clusterable> CentroidCluster<T> predict(List<CentroidCluster<T>> clusters, Clusterable point, DistanceMeasure measure) {
+        double minDistance = Double.POSITIVE_INFINITY;
+        CentroidCluster<T> nearestCluster = null;
+        for (CentroidCluster<T> cluster : clusters) {
+            double distance = measure.compute(point.getPoint(), cluster.getCenter().getPoint());
+            if (distance < minDistance) {
+                minDistance = distance;
+                nearestCluster = cluster;
+            }
         }
-        return list;
+        return nearestCluster;
     }
 
-    public static <T> ArrayList<T> shuffle(Collection<T> points) {
-        return shuffle(points, RandomSource.create(RandomSource.MT_64));
+    /**
+     * Predict which cluster is best for the point
+     *
+     * @param clusters cluster to predict into
+     * @param point    point to predict
+     * @param <T>      type of cluster point
+     * @return the cluster which has nearest center to the point
+     */
+    public static <T extends Clusterable> CentroidCluster<T> predict(List<CentroidCluster<T>> clusters, Clusterable point) {
+        return predict(clusters, point, DEFAULT_MEASURE);
     }
 
     /**

--- a/src/main/java/org/apache/commons/math4/ml/clustering/MiniBatchKMeansClusterer.java
+++ b/src/main/java/org/apache/commons/math4/ml/clustering/MiniBatchKMeansClusterer.java
@@ -1,0 +1,281 @@
+package org.apache.commons.math4.ml.clustering;
+
+import org.apache.commons.math4.exception.ConvergenceException;
+import org.apache.commons.math4.exception.MathIllegalArgumentException;
+import org.apache.commons.math4.exception.NumberIsTooSmallException;
+import org.apache.commons.math4.ml.clustering.initialization.CentroidInitializer;
+import org.apache.commons.math4.ml.clustering.initialization.KMeansPlusPlusCentroidInitializer;
+import org.apache.commons.math4.ml.distance.DistanceMeasure;
+import org.apache.commons.math4.ml.distance.EuclideanDistance;
+import org.apache.commons.math4.util.MathUtils;
+import org.apache.commons.math4.util.Pair;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * A very fast clustering algorithm base on KMeans(Refer to Python sklearn.cluster.MiniBatchKMeans)
+ * Use a partial points in initialize cluster centers, and mini batch in iterations.
+ * It finish in few seconds when clustering millions of data, and has few differences between KMeans.
+ * See https://www.eecs.tufts.edu/~dsculley/papers/fastkmeans.pdf
+ *
+ * @param <T> Type of the points to cluster
+ */
+public class MiniBatchKMeansClusterer<T extends Clusterable> extends Clusterer<T> {
+    /**
+     * The number of clusters.
+     */
+    private final int k;
+
+    /**
+     * The maximum number of iterations.
+     */
+    private final int maxIterations;
+
+    /**
+     * Batch data size in iteration.
+     */
+    private final int batchSize;
+    /**
+     * Iteration count of initialize the centers.
+     */
+    private final int initIterations;
+    /**
+     * Data size of batch to initialize the centers, default 3*k
+     */
+    private final int initBatchSize;
+    /**
+     * Max iterate times when no improvement on step iterations.
+     */
+    private final int maxNoImprovementTimes;
+    /**
+     * Random generator for choosing initial centers.
+     */
+    private final UniformRandomProvider random;
+
+    private final CentroidInitializer centroidInitializer;
+
+
+    /**
+     * Build a clusterer.
+     *
+     * @param k                     the number of clusters to split the data into
+     * @param maxIterations         the maximum number of iterations to run the algorithm for.
+     *                              If negative, no maximum will be used.
+     * @param batchSize             the mini batch size for training iterations.
+     * @param initIterations        the iterations to find out the best clusters centers.
+     * @param initBatchSize         the mini batch size to initial the clusters centers.
+     * @param maxNoImprovementTimes the max iterations times when the square distance has no improvement.
+     * @param measure               the distance measure to use
+     * @param random                random generator to use for choosing initial centers
+     *                              may appear during algorithm iterations
+     * @param centroidInitializer   the centroid initializer algorithm
+     */
+    public MiniBatchKMeansClusterer(final int k, int maxIterations, final int batchSize, final int initIterations,
+                                    final int initBatchSize, final int maxNoImprovementTimes,
+                                    final DistanceMeasure measure, final UniformRandomProvider random,
+                                    final CentroidInitializer centroidInitializer) {
+        super(measure);
+        this.k = k;
+        this.maxIterations = maxIterations;
+        this.batchSize = batchSize;
+        this.initIterations = initIterations;
+        this.initBatchSize = initBatchSize;
+        this.maxNoImprovementTimes = maxNoImprovementTimes;
+        this.random = random;
+        this.centroidInitializer = centroidInitializer;
+    }
+
+    /**
+     * Build a clusterer.
+     *
+     * @param k             the number of clusters to split the data into
+     * @param maxIterations the maximum number of iterations to run the algorithm for.
+     *                      If negative, no maximum will be used.
+     * @param measure       the distance measure to use
+     * @param random        random generator to use for choosing initial centers
+     *                      may appear during algorithm iterations
+     */
+    public MiniBatchKMeansClusterer(int k, int maxIterations, DistanceMeasure measure, UniformRandomProvider random) {
+        this(k, maxIterations, 100, 3, 100, 10,
+                measure, random, new KMeansPlusPlusCentroidInitializer(measure, random));
+    }
+
+
+    /**
+     * Build a clusterer.
+     *
+     * @param k the number of clusters to split the data into
+     */
+    public MiniBatchKMeansClusterer(int k) {
+        this(k, 100, new EuclideanDistance(), RandomSource.create(RandomSource.MT_64));
+    }
+
+    /**
+     * Runs the MiniBatch K-means clustering algorithm.
+     *
+     * @param points the points to cluster
+     * @return a list of clusters containing the points
+     * @throws MathIllegalArgumentException if the data points are null or the number
+     *                                      of clusters is larger than the number of data points
+     */
+    @Override
+    public List<CentroidCluster<T>> cluster(Collection<T> points) throws MathIllegalArgumentException, ConvergenceException {
+        // sanity checks
+        MathUtils.checkNotNull(points);
+
+        // number of clusters has to be smaller or equal the number of data points
+        if (points.size() < k) {
+            throw new NumberIsTooSmallException(points.size(), k, false);
+        }
+
+        int pointSize = points.size();
+        int batchCount = pointSize / batchSize + ((pointSize % batchSize > 0) ? 1 : 0);
+        int maxIterations = this.maxIterations * batchCount;
+        MiniBatchImprovementEvaluator evaluator = new MiniBatchImprovementEvaluator();
+        List<CentroidCluster<T>> clusters = initialCenters(points);
+        for (int i = 0; i < maxIterations; i++) {
+            //清空上次的分类结果
+            clearClustersPoints(clusters);
+            //随机抽样一批节点
+            List<T> batchPoints = randomMiniBatch(points, batchSize);
+            Pair<Double, List<CentroidCluster<T>>> pair = step(batchPoints, clusters);
+            double squareDistance = pair.getFirst();
+            clusters = pair.getSecond();
+            //评估改进情况
+            if (evaluator.convergence(squareDistance, pointSize)) break;
+        }
+        clearClustersPoints(clusters);
+        //所有结点按质心分类
+        for (T point : points) {
+            addToNearestCentroidCluster(point, clusters);
+        }
+        return clusters;
+    }
+
+    /**
+     * clear clustered points
+     *
+     * @param clusters The clusters to clear
+     */
+    private void clearClustersPoints(List<CentroidCluster<T>> clusters) {
+        for (CentroidCluster<T> cluster : clusters) {
+            cluster.getPoints().clear();
+        }
+    }
+
+    /**
+     * Mini batch iteration step
+     *
+     * @param batchPoints The mini batch points.
+     * @param clusters    The cluster centers.
+     * @return Square distance of all the batch points to the nearest center, and newly clusters.
+     */
+    protected Pair<Double, List<CentroidCluster<T>>> step(
+            List<T> batchPoints,
+            List<CentroidCluster<T>> clusters) {
+        //抽样结点归类
+        for (T point : batchPoints) {
+            addToNearestCentroidCluster(point, clusters);
+        }
+        List<CentroidCluster<T>> newClusters = new ArrayList<CentroidCluster<T>>(clusters.size());
+        //重算质心
+        for (CentroidCluster<T> cluster : clusters) {
+            Clusterable newCenter;
+            if (cluster.getPoints().isEmpty()) {
+                newCenter = new DoublePoint(ClusterUtils.getPointFromLargestVarianceCluster(clusters, this.getDistanceMeasure(), random).getPoint());
+            } else {
+                newCenter = ClusterUtils.centroidOf(cluster.getPoints(), cluster.getCenter().getPoint().length);
+            }
+            newClusters.add(new CentroidCluster<T>(newCenter));
+        }
+        //重新归类抽样结点
+        double squareDistance = 0.0;
+        for (T point : batchPoints) {
+            double d = addToNearestCentroidCluster(point, newClusters);
+            squareDistance += d * d;
+        }
+        return new Pair<Double, List<CentroidCluster<T>>>(squareDistance, newClusters);
+    }
+
+    protected List<T> randomMiniBatch(Collection<T> points, int batchSize) {
+        return ClusterUtils.shuffle(new ArrayList<T>(points), random).subList(0, batchSize);
+    }
+
+    /**
+     * Initial cluster centers with multiply iterations, find out the best.
+     *
+     * @param points Points use to initial the cluster centers.
+     * @return Clusters with center
+     */
+    protected List<CentroidCluster<T>> initialCenters(Collection<T> points) {
+        List<T> validPoints = initBatchSize < points.size() ? randomMiniBatch(points, initBatchSize) : new ArrayList<T>(points);
+        double nearestSquareDistance = Double.POSITIVE_INFINITY;
+        List<CentroidCluster<T>> bestCenters = null;
+        for (int i = 0; i < initIterations; i++) {
+            List<T> initialPoints = (initBatchSize < points.size()) ? randomMiniBatch(points, initBatchSize) : new ArrayList<T>(points);
+            List<CentroidCluster<T>> clusters = centroidInitializer.chooseCentroids(initialPoints, k);
+            Pair<Double, List<CentroidCluster<T>>> pair = step(validPoints, clusters);
+            double squareDistance = pair.getFirst();
+            List<CentroidCluster<T>> newClusters = pair.getSecond();
+            //Find out a best centers that has the nearest total square distance.
+            if (squareDistance < nearestSquareDistance) {
+                nearestSquareDistance = squareDistance;
+                bestCenters = newClusters;
+            }
+        }
+        return bestCenters;
+    }
+
+    /**
+     * Add a point to the cluster which the nearest center belong to.
+     *
+     * @param point    The point to add.
+     * @param clusters The clusters to add to.
+     * @return The distance to nearest center.
+     */
+    public double addToNearestCentroidCluster(T point, List<CentroidCluster<T>> clusters) {
+        double minDistance = Double.POSITIVE_INFINITY;
+        CentroidCluster<T> nearestCentroidCluster = null;
+        for (CentroidCluster<T> centroidCluster : clusters) {
+            double distance = distance(point, centroidCluster.getCenter());
+            if (distance < minDistance) {
+                minDistance = distance;
+                nearestCentroidCluster = centroidCluster;
+            }
+        }
+        assert nearestCentroidCluster != null;
+        nearestCentroidCluster.addPoint(point);
+        return minDistance;
+    }
+
+    /**
+     * The Evaluator to evaluate whether the iteration should finish where square has no improvement for appointed times.
+     */
+    class MiniBatchImprovementEvaluator {
+        private Double ewaInertia = null;
+        private double ewaInertiaMin = Double.POSITIVE_INFINITY;
+        private int noImprovementTimes = 0;
+
+        protected boolean convergence(double squareDistance, int pointSize) {
+            double batchInertia = squareDistance / batchSize;
+            if (ewaInertia == null) {
+                ewaInertia = batchInertia;
+            } else {
+                double alpha = batchSize * 2.0 / (pointSize + 1);
+                alpha = Math.min(alpha, 1.0);
+                ewaInertia = ewaInertia * (1 - alpha) + batchInertia * alpha;
+            }
+            if (ewaInertia < ewaInertiaMin) {
+                noImprovementTimes = 0;
+                ewaInertiaMin = ewaInertia;
+            } else {
+                noImprovementTimes++;
+            }
+            return noImprovementTimes >= maxNoImprovementTimes;
+        }
+    }
+}

--- a/src/main/java/org/apache/commons/math4/ml/clustering/initialization/CentroidInitializer.java
+++ b/src/main/java/org/apache/commons/math4/ml/clustering/initialization/CentroidInitializer.java
@@ -1,0 +1,22 @@
+package org.apache.commons.math4.ml.clustering.initialization;
+
+import org.apache.commons.math4.ml.clustering.CentroidCluster;
+import org.apache.commons.math4.ml.clustering.Clusterable;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Interface abstract the algorithm for clusterer to choose the initial centers.
+ */
+public interface CentroidInitializer {
+
+    /**
+     * Choose the initial centers.
+     *
+     * @param points the points to choose the initial centers from
+     * @param k      The number of clusters
+     * @return the initial centers
+     */
+    <T extends Clusterable> List<CentroidCluster<T>> chooseCentroids(final Collection<T> points, final int k);
+}

--- a/src/main/java/org/apache/commons/math4/ml/clustering/initialization/KMeansPlusPlusCentroidInitializer.java
+++ b/src/main/java/org/apache/commons/math4/ml/clustering/initialization/KMeansPlusPlusCentroidInitializer.java
@@ -1,0 +1,169 @@
+package org.apache.commons.math4.ml.clustering.initialization;
+
+import org.apache.commons.math4.ml.clustering.CentroidCluster;
+import org.apache.commons.math4.ml.clustering.Clusterable;
+import org.apache.commons.math4.ml.distance.DistanceMeasure;
+import org.apache.commons.rng.UniformRandomProvider;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Use K-means++ to choose the initial centers.
+ *
+ * @see <a href="http://en.wikipedia.org/wiki/K-means%2B%2B">K-means++ (wikipedia)</a>
+ */
+public class KMeansPlusPlusCentroidInitializer implements CentroidInitializer {
+    private final DistanceMeasure measure;
+    private final UniformRandomProvider random;
+
+    /**
+     * Build a K-means++ CentroidInitializer
+     * @param measure the distance measure to use
+     * @param random the random to use.
+     */
+    public KMeansPlusPlusCentroidInitializer(final DistanceMeasure measure, final UniformRandomProvider random) {
+        this.measure = measure;
+        this.random = random;
+    }
+
+    /**
+     * Use K-means++ to choose the initial centers.
+     *
+     * @param points the points to choose the initial centers from
+     * @param k      The number of clusters
+     * @return the initial centers
+     */
+    @Override
+    public <T extends Clusterable> List<CentroidCluster<T>> chooseCentroids(final Collection<T> points, final int k) {
+        // Convert to list for indexed access. Make it unmodifiable, since removal of items
+        // would screw up the logic of this method.
+        final List<T> pointList = Collections.unmodifiableList(new ArrayList<>(points));
+
+        // The number of points in the list.
+        final int numPoints = pointList.size();
+
+        // Set the corresponding element in this array to indicate when
+        // elements of pointList are no longer available.
+        final boolean[] taken = new boolean[numPoints];
+
+        // The resulting list of initial centers.
+        final List<CentroidCluster<T>> resultSet = new ArrayList<>();
+
+        // Choose one center uniformly at random from among the data points.
+        final int firstPointIndex = random.nextInt(numPoints);
+
+        final T firstPoint = pointList.get(firstPointIndex);
+
+        resultSet.add(new CentroidCluster<T>(firstPoint));
+
+        // Must mark it as taken
+        taken[firstPointIndex] = true;
+
+        // To keep track of the minimum distance squared of elements of
+        // pointList to elements of resultSet.
+        final double[] minDistSquared = new double[numPoints];
+
+        // Initialize the elements.  Since the only point in resultSet is firstPoint,
+        // this is very easy.
+        for (int i = 0; i < numPoints; i++) {
+            if (i != firstPointIndex) { // That point isn't considered
+                double d = distance(firstPoint, pointList.get(i));
+                minDistSquared[i] = d * d;
+            }
+        }
+
+        while (resultSet.size() < k) {
+
+            // Sum up the squared distances for the points in pointList not
+            // already taken.
+            double distSqSum = 0.0;
+
+            for (int i = 0; i < numPoints; i++) {
+                if (!taken[i]) {
+                    distSqSum += minDistSquared[i];
+                }
+            }
+
+            // Add one new data point as a center. Each point x is chosen with
+            // probability proportional to D(x)2
+            final double r = random.nextDouble() * distSqSum;
+
+            // The index of the next point to be added to the resultSet.
+            int nextPointIndex = -1;
+
+            // Sum through the squared min distances again, stopping when
+            // sum >= r.
+            double sum = 0.0;
+            for (int i = 0; i < numPoints; i++) {
+                if (!taken[i]) {
+                    sum += minDistSquared[i];
+                    if (sum >= r) {
+                        nextPointIndex = i;
+                        break;
+                    }
+                }
+            }
+
+            // If it's not set to >= 0, the point wasn't found in the previous
+            // for loop, probably because distances are extremely small.  Just pick
+            // the last available point.
+            if (nextPointIndex == -1) {
+                for (int i = numPoints - 1; i >= 0; i--) {
+                    if (!taken[i]) {
+                        nextPointIndex = i;
+                        break;
+                    }
+                }
+            }
+
+            // We found one.
+            if (nextPointIndex >= 0) {
+
+                final T p = pointList.get(nextPointIndex);
+
+                resultSet.add(new CentroidCluster<T>(p));
+
+                // Mark it as taken.
+                taken[nextPointIndex] = true;
+
+                if (resultSet.size() < k) {
+                    // Now update elements of minDistSquared.  We only have to compute
+                    // the distance to the new center to do this.
+                    for (int j = 0; j < numPoints; j++) {
+                        // Only have to worry about the points still not taken.
+                        if (!taken[j]) {
+                            double d = distance(p, pointList.get(j));
+                            double d2 = d * d;
+                            if (d2 < minDistSquared[j]) {
+                                minDistSquared[j] = d2;
+                            }
+                        }
+                    }
+                }
+
+            } else {
+                // None found --
+                // Break from the while loop to prevent
+                // an infinite loop.
+                break;
+            }
+        }
+
+        return resultSet;
+    }
+
+    /**
+     * Calculates the distance between two {@link Clusterable} instances
+     * with the configured {@link DistanceMeasure}.
+     *
+     * @param p1 the first clusterable
+     * @param p2 the second clusterable
+     * @return the distance between the two clusterables
+     */
+    protected double distance(final Clusterable p1, final Clusterable p2) {
+        return measure.compute(p1.getPoint(), p2.getPoint());
+    }
+}

--- a/src/main/java/org/apache/commons/math4/ml/clustering/initialization/RandomCentroidInitializer.java
+++ b/src/main/java/org/apache/commons/math4/ml/clustering/initialization/RandomCentroidInitializer.java
@@ -1,0 +1,41 @@
+package org.apache.commons.math4.ml.clustering.initialization;
+
+import org.apache.commons.math4.ml.clustering.CentroidCluster;
+import org.apache.commons.math4.ml.clustering.ClusterUtils;
+import org.apache.commons.math4.ml.clustering.Clusterable;
+import org.apache.commons.rng.UniformRandomProvider;
+
+import java.util.*;
+
+/**
+ * Random choose the initial centers.
+ */
+public class RandomCentroidInitializer implements CentroidInitializer {
+    private final UniformRandomProvider random;
+
+    /**
+     * Build a random RandomCentroidInitializer
+     *
+     * @param random the random to use.
+     */
+    public RandomCentroidInitializer(final UniformRandomProvider random) {
+        this.random = random;
+    }
+
+    /**
+     * Random choose the initial centers.
+     *
+     * @param points the points to choose the initial centers from
+     * @param k      The number of clusters
+     * @return the initial centers
+     */
+    @Override
+    public <T extends Clusterable> List<CentroidCluster<T>> chooseCentroids(Collection<T> points, int k) {
+        ArrayList<T> list = ClusterUtils.shuffle(points, random);
+        List<CentroidCluster<T>> result = new ArrayList<>(k);
+        for (int i = 0; i < k; i++) {
+            result.add(new CentroidCluster<>(list.get(i)));
+        }
+        return result;
+    }
+}

--- a/src/main/java/org/apache/commons/math4/ml/clustering/initialization/RandomCentroidInitializer.java
+++ b/src/main/java/org/apache/commons/math4/ml/clustering/initialization/RandomCentroidInitializer.java
@@ -1,11 +1,13 @@
 package org.apache.commons.math4.ml.clustering.initialization;
 
 import org.apache.commons.math4.ml.clustering.CentroidCluster;
-import org.apache.commons.math4.ml.clustering.ClusterUtils;
 import org.apache.commons.math4.ml.clustering.Clusterable;
 import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.sampling.ListSampler;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Random choose the initial centers.
@@ -31,7 +33,8 @@ public class RandomCentroidInitializer implements CentroidInitializer {
      */
     @Override
     public <T extends Clusterable> List<CentroidCluster<T>> chooseCentroids(Collection<T> points, int k) {
-        ArrayList<T> list = ClusterUtils.shuffle(points, random);
+        ArrayList<T> list = new ArrayList<T>(points);
+        ListSampler.shuffle(random, list);
         List<CentroidCluster<T>> result = new ArrayList<>(k);
         for (int i = 0; i < k; i++) {
             result.add(new CentroidCluster<>(list.get(i)));

--- a/src/test/java/org/apache/commons/math4/ml/clustering/MiniBatchKMeansClustererTest.java
+++ b/src/test/java/org/apache/commons/math4/ml/clustering/MiniBatchKMeansClustererTest.java
@@ -1,0 +1,111 @@
+package org.apache.commons.math4.ml.clustering;
+
+import org.apache.commons.math4.linear.MatrixUtils;
+import org.apache.commons.math4.linear.RealMatrix;
+import org.apache.commons.math4.ml.distance.DistanceMeasure;
+import org.apache.commons.math4.ml.distance.EuclideanDistance;
+import org.apache.commons.math4.random.CorrelatedRandomVectorGenerator;
+import org.apache.commons.math4.random.GaussianRandomGenerator;
+import org.apache.commons.rng.UniformRandomProvider;
+import org.apache.commons.rng.simple.RandomSource;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+public class MiniBatchKMeansClustererTest {
+    private DistanceMeasure measure = new EuclideanDistance();
+
+    @Test
+    public void compareToKMeans() {
+        //Generate 4 cluster
+        List<DoublePoint> data = generateCircles();
+        KMeansPlusPlusClusterer<DoublePoint> kMeans = new KMeansPlusPlusClusterer<>(4);
+        MiniBatchKMeansClusterer<DoublePoint> miniBatchKMeans = new MiniBatchKMeansClusterer<>(4);
+        List<CentroidCluster<DoublePoint>> kMeansClusters = kMeans.cluster(data);
+        List<CentroidCluster<DoublePoint>> miniBatchKMeansClusters = miniBatchKMeans.cluster(data);
+        Assert.assertEquals(4, kMeansClusters.size());
+        Assert.assertEquals(kMeansClusters.size(), miniBatchKMeansClusters.size());
+        int totalDiffCount = 0;
+        double totalCenterDistance = 0.0;
+        for (CentroidCluster<DoublePoint> kMeanCluster : kMeansClusters) {
+            CentroidCluster<DoublePoint> miniBatchCluster = predict(kMeanCluster.getCenter(), miniBatchKMeansClusters);
+            totalDiffCount += Math.abs(kMeanCluster.getPoints().size() - miniBatchCluster.getPoints().size());
+            totalCenterDistance += measure.compute(kMeanCluster.getCenter().getPoint(), miniBatchCluster.getCenter().getPoint());
+        }
+        double diffRatio = totalDiffCount * 1.0 / data.size();
+        System.out.println(String.format("Centers total distance: %f, clusters total diff points: %d, diff ratio: %f%%",
+                totalCenterDistance, totalDiffCount, diffRatio * 100));
+        // Difference ratio less than 2%
+        Assert.assertTrue(String.format("Different points ratio %f%%!", diffRatio * 100), diffRatio < 0.02);
+    }
+
+    private <T extends Clusterable> CentroidCluster<T> predict(Clusterable point, List<CentroidCluster<T>> clusters) {
+        double minDistance = Double.POSITIVE_INFINITY;
+        CentroidCluster<T> nearestCluster = null;
+        for (CentroidCluster<T> cluster : clusters) {
+            double distance = measure.compute(point.getPoint(), cluster.getCenter().getPoint());
+            if (distance < minDistance) {
+                minDistance = distance;
+                nearestCluster = cluster;
+            }
+        }
+        return nearestCluster;
+    }
+
+    private List<DoublePoint> generateClusters() {
+        List<DoublePoint> data = new ArrayList<>();
+        data.addAll(generateCluster(250, new double[]{-1.0, -1.0}, 0.5));
+        data.addAll(generateCluster(250, new double[]{0.0, 0.0}, 0.5));
+        data.addAll(generateCluster(250, new double[]{1.0, 1.0}, 0.5));
+        data.addAll(generateCluster(250, new double[]{2.0, 2.0}, 0.5));
+        return data;
+    }
+
+    private List<DoublePoint> generateCluster(int size, double[] center, double radius) {
+        UniformRandomProvider rg = RandomSource.create(RandomSource.MT_64, 0);
+        GaussianRandomGenerator rawGenerator = new GaussianRandomGenerator(rg);
+        double[] standardDeviation = {0.5, 0.5};
+        double c = standardDeviation[0] * standardDeviation[1] * radius;
+        double[][] cov = {{standardDeviation[0] * standardDeviation[0], c}, {c, standardDeviation[1] * standardDeviation[1]}};
+        RealMatrix covariance = MatrixUtils.createRealMatrix(cov);
+        // Create a CorrelatedRandomVectorGenerator using "rawGenerator" for the components.
+        CorrelatedRandomVectorGenerator generator =
+                new CorrelatedRandomVectorGenerator(center, covariance, 1.0e-12 * covariance.getNorm(), rawGenerator);
+        // Use the generator to generate correlated vectors.
+        List<DoublePoint> data = new ArrayList<DoublePoint>(size);
+        for (int i = 0; i < size; i++) {
+            // Use the generator to generate vectors
+            double[] randomVector = generator.nextVector();
+            data.add(new DoublePoint(randomVector));
+        }
+        return data;
+    }
+
+    private List<DoublePoint> generateCircles() {
+        List<DoublePoint> data = new ArrayList<>();
+        Random random = new Random(0);
+        data.addAll(generateCircle(250, new double[]{-1.0, -1.0}, 1.0, random));
+        data.addAll(generateCircle(250, new double[]{0.0, 0.0}, 0.7, random));
+        data.addAll(generateCircle(250, new double[]{1.0, 1.0}, 0.7, random));
+        data.addAll(generateCircle(250, new double[]{2.0, 2.0}, 0.7, random));
+        return data;
+    }
+
+    List<DoublePoint> generateCircle(int count, double[] center, double radius, Random random) {
+        double x0 = center[0];
+        double y0 = center[1];
+        ArrayList<DoublePoint> list = new ArrayList<DoublePoint>(count);
+        for (int i = 0; i < count; i++) {
+            double ao = random.nextDouble() * 720 - 360;
+            double r = random.nextDouble() * radius * 2 - radius;
+            double x1 = x0 + r * Math.cos(ao * Math.PI / 180);
+            double y1 = y0 + r * Math.sin(ao * Math.PI / 180);
+            list.add(new DoublePoint(new double[]{x1, y1}));
+        }
+        return list;
+    }
+
+}


### PR DESCRIPTION
Implement the MiniBatchKMeansClusterer and unit test that compare to KMeansPlusPlusClusterer
MiniBatchKMeans is a fast clustering algorithm base on KMeans(Refer to Python sklearn.cluster.MiniBatchKMeans)
Use a partial points in initialize cluster centers, and mini batch in iterations.
It can finish in few seconds when clustering millions of data, and has few differences between KMeans.
See https://www.eecs.tufts.edu/~dsculley/papers/fastkmeans.pdf