### PR TITLE
EnumeratedDistribution: Use non-indexing for loop to improve performance in case of LinkedList

### DIFF
--- a/src/main/java/org/apache/commons/math4/distribution/EnumeratedDistribution.java
+++ b/src/main/java/org/apache/commons/math4/distribution/EnumeratedDistribution.java
@@ -86,9 +86,8 @@ public class EnumeratedDistribution<T> implements Serializable {
                NotANumberException {
         singletons = new ArrayList<>(pmf.size());
         final double[] probs = new double[pmf.size()];
-
-        for (int i = 0; i < pmf.size(); i++) {
-            final Pair<T, Double> sample = pmf.get(i);
+        int i = 0;
+        for (Pair<T, Double> sample : pmf) {
             singletons.add(sample.getKey());
             final double p = sample.getValue();
             if (p < 0) {
@@ -101,13 +100,14 @@ public class EnumeratedDistribution<T> implements Serializable {
                 throw new NotANumberException();
             }
             probs[i] = p;
+            i++;
         }
 
         probabilities = MathArrays.normalizeArray(probs, 1.0);
 
         cumulativeProbabilities = new double[probabilities.length];
         double sum = 0;
-        for (int i = 0; i < probabilities.length; i++) {
+        for (i = 0; i < probabilities.length; i++) {
             sum += probabilities[i];
             cumulativeProbabilities[i] = sum;
         }

--- a/src/main/java/org/apache/commons/math4/distribution/EnumeratedDistribution.java
+++ b/src/main/java/org/apache/commons/math4/distribution/EnumeratedDistribution.java
@@ -107,9 +107,9 @@ public class EnumeratedDistribution<T> implements Serializable {
 
         cumulativeProbabilities = new double[probabilities.length];
         double sum = 0;
-        for (i = 0; i < probabilities.length; i++) {
-            sum += probabilities[i];
-            cumulativeProbabilities[i] = sum;
+        for (int j = 0; j < probabilities.length; j++) {
+            sum += probabilities[j];
+            cumulativeProbabilities[j] = sum;
         }
     }
 


### PR DESCRIPTION
In case if `List<Pair<T, Double>> pmf` is LinkedList, the runtime for constructor of the EnumeratedDistribution becomes quadratic to the length of pmf because of accessing i-th element by index. Accessing i-th element of LinkedList is linear. Just replaced the population of `singletons` with  enhanced for-loop.