### PR TITLE
[MATH-1542] remove `== null` as it is covered by `instance of`

### DIFF
--- a/src/main/java/org/apache/commons/math4/analysis/polynomials/PolynomialsUtils.java
+++ b/src/main/java/org/apache/commons/math4/analysis/polynomials/PolynomialsUtils.java
@@ -299,7 +299,7 @@ public class PolynomialsUtils {
         @Override
         public boolean equals(final Object key) {
 
-            if ((key == null) || !(key instanceof JacobiKey)) {
+            if (!(key instanceof JacobiKey)) {
                 return false;
             }
 


### PR DESCRIPTION
Or, is it for special optimization strategy?