### PR TITLE
[MATH-1544] delete a needless (IMO) null for double varargs parameter.

### DIFF
--- a/src/main/java/org/apache/commons/math4/util/ResizableDoubleArray.java
+++ b/src/main/java/org/apache/commons/math4/util/ResizableDoubleArray.java
@@ -245,7 +245,7 @@ public class ResizableDoubleArray implements DoubleArray, Serializable {
      */
     public ResizableDoubleArray(int initialCapacity, double expansionFactor, double contractionCriterion)
         throws MathIllegalArgumentException {
-        this(initialCapacity, expansionFactor, contractionCriterion, DEFAULT_EXPANSION_MODE, null);
+        this(initialCapacity, expansionFactor, contractionCriterion, DEFAULT_EXPANSION_MODE);
     }
 
     /**


### PR DESCRIPTION
after deleting it, it still point to the same constructor IMO.