### PR TITLE
Why we compare two Integers with == but not equals()?

### DIFF
--- a/src/main/java/org/apache/commons/math4/genetics/RandomKey.java
+++ b/src/main/java/org/apache/commons/math4/genetics/RandomKey.java
@@ -163,7 +163,7 @@ public abstract class RandomKey<T> extends AbstractListChromosome<Double> implem
         List<Integer> anotherPerm = anotherRk.baseSeqPermutation;
 
         for (int i=0; i<getLength(); i++) {
-            if (thisPerm.get(i) != anotherPerm.get(i)) {
+            if (thisPerm.get(i).equals(anotherPerm.get(i))) {
                 return false;
             }
         }


### PR DESCRIPTION
I see codes related to this and cannot find a proof for doing so.
If it is specially designed please tell me the reason and close this pr.
thanks.