### PR TITLE
[MATH-1545] Follow best practice to test ordering in implementation of Comparable

### DIFF
--- a/src/main/java/org/apache/commons/math4/stat/inference/KolmogorovSmirnovTest.java
+++ b/src/main/java/org/apache/commons/math4/stat/inference/KolmogorovSmirnovTest.java
@@ -739,7 +739,7 @@ public class KolmogorovSmirnovTest {
          * [1] states: "For 1/2 < h < 1 the bottom left element of the matrix should be (1 - 2*h^m +
          * (2h - 1)^m )/m!" Since 0 <= h < 1, then if h > 1/2 is sufficient to check:
          */
-        if (h.compareTo(ONE_HALF) == 1) {
+        if (h.compareTo(ONE_HALF) > 0) {
             Hdata.set(m - 1, 0,
                       Hdata.get(m - 1, 0).add(h.multiply(2).subtract(1).pow(m)));
         }


### PR DESCRIPTION
Though many implementations of Comparable (including BigFraction) returns only [0, -1, 1] for compareTo function, usually we do not use `== 1` to detect the result, but use [>0, ==0, <0], which is defined in javadoc of class Compare.
Of course == 1 is correct here, as BigFraction is a final class and nobody can override this compareTo function.
But I still think it be better to change it to > 0.