### PR TITLE
Add convenience method for initialization

### DIFF
--- a/src/main/java/org/apache/commons/math4/stat/descriptive/SummaryStatistics.java
+++ b/src/main/java/org/apache/commons/math4/stat/descriptive/SummaryStatistics.java
@@ -133,6 +133,26 @@ public class SummaryStatistics implements StatisticalSummary, Serializable {
     }
 
     /**
+     * Construct a SummaryStatistics instance filling it with the given initialDoubleArray
+     * @param initialDoubleArray values for filling the array
+     */
+    public SummaryStatistics(double[] initialDoubleArray) {
+        for (double initialValue : initialDoubleArray) {
+           addValue(initialValue);
+        }
+    }
+
+    /**
+     * Construct a SummaryStatistics instance filling it with the given initialDoubleArray
+     * @param initialDoubleArray values for filling the array
+     */
+    public SummaryStatistics(Double[] initialDoubleArray) {
+        for (Double initialValue : initialDoubleArray) {
+           addValue(initialValue);
+        }
+    }
+
+    /**
      * Return a {@link StatisticalSummaryValues} instance reporting current
      * statistics.
      * @return Current values of statistics

--- a/src/test/java/org/apache/commons/math4/stat/descriptive/SummaryStatisticsTest.java
+++ b/src/test/java/org/apache/commons/math4/stat/descriptive/SummaryStatisticsTest.java
@@ -315,6 +315,9 @@ public class SummaryStatisticsTest {
         expected = Math.sqrt(expected);
 
         Assert.assertEquals(expected, stats.getQuadraticMean(), Math.ulp(expected));
+
+        SummaryStatistics convenienceMethodStatistics = new SummaryStatistics(values);
+        Assert.assertEquals(expected, convenienceMethodStatistics.getQuadraticMean(), Math.ulp(expected));	
     }
 
     /**


### PR DESCRIPTION
While DescriptiveStatistics can be initialized with double[] or Double[], this is not possible for SummaryStatistics. To easy the use, I recommend to add constructors enabling this initialization. 