### PR TITLE
Standardize constants before running simplex algorithm. Fixes MATH-1549.

### DIFF
--- a/src/test/java/org/apache/commons/math4/optim/linear/SimplexSolverTest.java
+++ b/src/test/java/org/apache/commons/math4/optim/linear/SimplexSolverTest.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.Assert;
 
 import org.apache.commons.numbers.core.Precision;
@@ -28,16 +27,6 @@ import org.apache.commons.math4.exception.DimensionMismatchException;
 import org.apache.commons.math4.exception.TooManyIterationsException;
 import org.apache.commons.math4.optim.MaxIter;
 import org.apache.commons.math4.optim.PointValuePair;
-import org.apache.commons.math4.optim.linear.LinearConstraint;
-import org.apache.commons.math4.optim.linear.LinearConstraintSet;
-import org.apache.commons.math4.optim.linear.LinearObjectiveFunction;
-import org.apache.commons.math4.optim.linear.NoFeasibleSolutionException;
-import org.apache.commons.math4.optim.linear.NonNegativeConstraint;
-import org.apache.commons.math4.optim.linear.PivotSelectionRule;
-import org.apache.commons.math4.optim.linear.Relationship;
-import org.apache.commons.math4.optim.linear.SimplexSolver;
-import org.apache.commons.math4.optim.linear.SolutionCallback;
-import org.apache.commons.math4.optim.linear.UnboundedSolutionException;
 import org.apache.commons.math4.optim.nonlinear.scalar.GoalType;
 
 public class SimplexSolverTest {
@@ -820,24 +809,14 @@ public class SimplexSolverTest {
                         PivotSelectionRule.BLAND);
     }
 
-    /* XXX Skipped until issue is solved: https://issues.apache.org/jira/browse/MATH-1549 */
-    @Ignore@Test
+    /* linear transformation of constants should produce the same result */
+    @Test
     public void testMath1549() {
         final double m = 10;
-        double scale = 1;
-        int numFailures = 0;
-        for (int pow = 0; pow < 13; pow++) {
-            try {
-                tryMath1549(scale);
-            } catch (RuntimeException e) {
-                e.printStackTrace();
-                ++numFailures;
-            }
+        double scale = 1e-12;
+        for (int pow = 0; pow < 26; pow++) {
+            tryMath1549(scale);
             scale *= m;
-        }
-
-        if (numFailures > 0) {
-            Assert.fail(numFailures + " failures");
         }
     }
 
@@ -857,7 +836,7 @@ public class SimplexSolverTest {
         final LinearConstraintSet constraintSet = new LinearConstraintSet(constraints);
         final PointValuePair solution = solver.optimize(f, constraintSet, GoalType.MINIMIZE, nnegconstr);
 
-        System.out.println("scale=" + scale + ": sol=" + java.util.Arrays.toString(solution.getPoint()));
+        Assert.assertEquals(2.0, solution.getPoint()[0], eps);
     }
 
     /**

--- a/src/test/java/org/apache/commons/math4/optim/linear/SimplexTableauTest.java
+++ b/src/test/java/org/apache/commons/math4/optim/linear/SimplexTableauTest.java
@@ -20,10 +20,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 import org.apache.commons.math4.TestUtils;
-import org.apache.commons.math4.optim.linear.LinearConstraint;
-import org.apache.commons.math4.optim.linear.LinearObjectiveFunction;
-import org.apache.commons.math4.optim.linear.Relationship;
-import org.apache.commons.math4.optim.linear.SimplexTableau;
 import org.apache.commons.math4.optim.nonlinear.scalar.GoalType;
 import org.junit.Assert;
 import org.junit.Test;
@@ -38,7 +34,7 @@ public class SimplexTableauTest {
             new SimplexTableau(f, constraints, GoalType.MAXIMIZE, false, 1.0e-6);
         double[][] expectedInitialTableau = {
                                              {-1, 0,  -1,  -1,  2, 0, 0, 0, -4},
-                                             { 0, 1, -15, -10, 25, 0, 0, 0,  0},
+                                             { 0, 1, -1.875, -1.25, 3.125, 0, 0, 0,  0},
                                              { 0, 0,   1,   0, -1, 1, 0, 0,  2},
                                              { 0, 0,   0,   1, -1, 0, 1, 0,  3},
                                              { 0, 0,   1,   1, -2, 0, 0, 1,  4}
@@ -53,7 +49,7 @@ public class SimplexTableauTest {
         SimplexTableau tableau =
             new SimplexTableau(f, constraints, GoalType.MAXIMIZE, false, 1.0e-6);
         double[][] expectedTableau = {
-                                      { 1, -15, -10, 0, 0, 0, 0},
+                                      { 1, -1.875, -1.25, 0, 0, 0, 0},
                                       { 0,   1,   0, 1, 0, 0, 2},
                                       { 0,   0,   1, 0, 1, 0, 3},
                                       { 0,   1,   1, 0, 0, 1, 4}
@@ -72,7 +68,7 @@ public class SimplexTableauTest {
         SimplexTableau tableau =
             new SimplexTableau(f, constraints, GoalType.MAXIMIZE, false, 1.0e-6);
         double[][] initialTableau = {
-                                     {1, -15, -10, 25, 0, 0, 0, 0},
+                                     {1, -1.875, -1.25, 3.125, 0, 0, 0, 0},
                                      {0,   1,   0, -1, 1, 0, 0, 2},
                                      {0,   0,   1, -1, 0, 1, 0, 3},
                                      {0,   1,   1, -2, 0, 0, 1, 4}


### PR DESCRIPTION
I looked at MATH-1549 and the core issue is deep inside the algorithm. Basically, it's just doing division and subtraction (see `SimplexTableau.performRowOperations`). That set of operations amplifies small differences and starting with larger constants will cause problems in a matrix that's also filled with 1's and -1's.  Part of the problem comes from the fact that floating point multiplication + division does not produce the same result:

```java
    double d = 10.0/3.0;
    double scale = 100.0;
    System.out.println("Diff: "+(d - d * scale / scale)); // prints non-zero
```

The other part of the problem is that the epsilon parameter is not used to look at the convergence of the solution (alone), but also some internal computations. That makes reasoning about epsilon very hard. 

The proposed solution scales all constants linearly to be closer to 1 by using double exponent changes to avoid any bit errors.