### PR TITLE
[MATH-1559] Fix assertion failure with epsilon 

### DIFF
--- a/src/test/java/org/apache/commons/math4/distribution/EnumeratedRealDistributionTest.java
+++ b/src/test/java/org/apache/commons/math4/distribution/EnumeratedRealDistributionTest.java
@@ -248,7 +248,7 @@ public class EnumeratedRealDistributionTest {
     public void testCreateFromDoubles() {
         final double[] data = new double[] {0, 1, 1, 2, 2, 2};
         EnumeratedRealDistribution distribution = new EnumeratedRealDistribution(data);
-        assertEquals(0.5, distribution.probability(2), 0);
+        assertEquals(0.5, distribution.probability(2), 1e-15);
         assertEquals(0.5, distribution.cumulativeProbability(1), 0);
     }
 }


### PR DESCRIPTION
For detailed description of the issue, see: https://issues.apache.org/jira/browse/MATH-1559

If we just want to change the test so that it will always pass, this PR achieves it by setting a small epsilon (1e-15) in `assertEquals(0.5, distribution.probability(2), 1e-15)`. Otherwise to fix the issue, the source code, in particular `MathArrays.normalizeArray()` needs change.