### PR TITLE
Add convenience constructor for StatisticalSummaryValues

### DIFF
--- a/src/main/java/org/apache/commons/math4/stat/descriptive/StatisticalSummaryValues.java
+++ b/src/main/java/org/apache/commons/math4/stat/descriptive/StatisticalSummaryValues.java
@@ -70,6 +70,26 @@ public class StatisticalSummaryValues implements Serializable,
         this.min = min;
         this.sum = sum;
     }
+    
+    /**
+     * Convenience constructor which calculates the sum of values as mean*n
+     *
+     * @param mean  the sample mean
+     * @param variance  the sample variance
+     * @param n  the number of observations in the sample
+     * @param max  the maximum value
+     * @param min  the minimum value
+    */
+   public StatisticalSummaryValues(double mean, double variance, long n,
+       double max, double min) {
+       super();
+       this.mean = mean;
+       this.variance = variance;
+       this.n = n;
+       this.max = max;
+       this.min = min;
+       this.sum = mean * n;
+   }
 
     /**
      * @return Returns the max.

--- a/src/test/java/org/apache/commons/math4/stat/descriptive/StatisticalSummaryValuesTest.java
+++ b/src/test/java/org/apache/commons/math4/stat/descriptive/StatisticalSummaryValuesTest.java
@@ -79,4 +79,10 @@ public final class StatisticalSummaryValuesTest {
                      "sum: 45.0\n",  u.toString());
         Locale.setDefault(d);
     }
+    
+    @Test
+    public void testSum() {
+        StatisticalSummaryValues u = new StatisticalSummaryValues(1.123, 2, 3, 4, 5);
+        Assert.assertEquals(3.369, u.getSum(), 0.0001);
+    }
 }


### PR DESCRIPTION
If `StatisticalSummaryValues` are created manually, its easier if the sum does not need to be passed.