### PR TITLE
Shutdown execution services (in test classes) once the results are taken

### DIFF
--- a/src/test/java/org/apache/commons/math4/analysis/integration/gauss/BaseRuleFactoryTest.java
+++ b/src/test/java/org/apache/commons/math4/analysis/integration/gauss/BaseRuleFactoryTest.java
@@ -59,6 +59,7 @@ public class BaseRuleFactoryTest {
         for (Future<Pair<double[], double[]>> f : results) {
             f.get();
         }
+        exec.shutdown();
 
         // Assertion would fail if "getRuleInternal" were not "synchronized".
         final int n = RuleBuilder.getNumberOfCalls();

--- a/src/test/java/org/apache/commons/math4/random/SynchronizedRandomGeneratorTest.java
+++ b/src/test/java/org/apache/commons/math4/random/SynchronizedRandomGeneratorTest.java
@@ -114,6 +114,7 @@ public class SynchronizedRandomGeneratorTest {
         for (int i = 0; i < numGenerators; i++) {
             values[i] = results.get(i).get();
         }
+        exec.shutdown();
         return values;
     }
 }


### PR DESCRIPTION
Depending on the (JUnit) runner used, the execution might never terminate without these extra shutdown calls.