### PR TITLE
https://issues.apache.org/jira/browse/MATH-1453

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Alternatively you can pull it from the central Maven repositories:
 <dependency>
   <groupId>org.apache.commons</groupId>
   <artifactId>commons-math3</artifactId>
-  <version>3.5</version>
+  <version>3.6.1</version>
 </dependency>
 ```
 

--- a/src/main/java/org/apache/commons/math4/stat/inference/MannWhitneyUTest.java
+++ b/src/main/java/org/apache/commons/math4/stat/inference/MannWhitneyUTest.java
@@ -283,7 +283,7 @@ public class MannWhitneyUTest {
 
         ensureDataConformance(x, y);
 
-        final double Umax = mannWhitneyU(x, y);
+        final double Umax = mannWhitneyUMax(x, y);
 
         /*
          * It can be shown that U1 + U2 = n1 * n2

--- a/src/main/java/org/apache/commons/math4/stat/inference/MannWhitneyUTest.java
+++ b/src/main/java/org/apache/commons/math4/stat/inference/MannWhitneyUTest.java
@@ -117,11 +117,71 @@ public class MannWhitneyUTest {
      *
      * @param x the first sample
      * @param y the second sample
+     * @return Mann-Whitney U statistic (minimum of U<sup>x</sup> and U<sup>y</sup>)
+     * @throws NullArgumentException if {@code x} or {@code y} are {@code null}.
+     * @throws NoDataException if {@code x} or {@code y} are zero-length.
+     */
+    public double mannWhitneyUMin(final double[] x, final double[] y)
+        throws NullArgumentException, NoDataException {
+
+        ensureDataConformance(x, y);
+
+        final double[] z = concatenateSamples(x, y);
+        final double[] ranks = naturalRanking.rank(z);
+
+        double sumRankX = 0;
+
+        /*
+         * The ranks for x is in the first x.length entries in ranks because x
+         * is in the first x.length entries in z
+         */
+        for (int i = 0; i < x.length; ++i) {
+            sumRankX += ranks[i];
+        }
+
+        /*
+         * U1 = R1 - (n1 * (n1 + 1)) / 2 where R1 is sum of ranks for sample 1,
+         * e.g. x, n1 is the number of observations in sample 1.
+         */
+        final double U1 = sumRankX - ((long) x.length * (x.length + 1)) / 2;
+
+        /*
+         * It can be shown that U1 + U2 = n1 * n2
+         */
+        final double U2 = (long) x.length * y.length - U1;
+
+        return FastMath.min(U1, U2);
+    }
+
+
+    /**
+     * Computes the <a
+     * href="http://en.wikipedia.org/wiki/Mann%E2%80%93Whitney_U"> Mann-Whitney
+     * U statistic</a> comparing mean for two independent samples possibly of
+     * different length.
+     * <p>
+     * This statistic can be used to perform a Mann-Whitney U test evaluating
+     * the null hypothesis that the two independent samples has equal mean.
+     * </p>
+     * <p>
+     * Let X<sub>i</sub> denote the i'th individual of the first sample and
+     * Y<sub>j</sub> the j'th individual in the second sample. Note that the
+     * samples would often have different length.
+     * </p>
+     * <p>
+     * <strong>Preconditions</strong>:
+     * <ul>
+     * <li>All observations in the two samples are independent.</li>
+     * <li>The observations are at least ordinal (continuous are also ordinal).</li>
+     * </ul>
+     *
+     * @param x the first sample
+     * @param y the second sample
      * @return Mann-Whitney U statistic (maximum of U<sup>x</sup> and U<sup>y</sup>)
      * @throws NullArgumentException if {@code x} or {@code y} are {@code null}.
      * @throws NoDataException if {@code x} or {@code y} are zero-length.
      */
-    public double mannWhitneyU(final double[] x, final double[] y)
+    public double mannWhitneyUMax(final double[] x, final double[] y)
         throws NullArgumentException, NoDataException {
 
         ensureDataConformance(x, y);

--- a/src/test/java/org/apache/commons/math4/stat/inference/MannWhitneyUTestMinTest.java
+++ b/src/test/java/org/apache/commons/math4/stat/inference/MannWhitneyUTestMinTest.java
@@ -42,8 +42,8 @@ public class MannWhitneyUTestTest {
         final double x[] = {19, 22, 16, 29, 24};
         final double y[] = {20, 11, 17, 12};
 
-        Assert.assertEquals(17, testStatistic.mannWhitneyUMax(x, y), 1e-10);
-        Assert.assertEquals(0.08641, testStatistic.mannWhitneyUTestMax(x, y), 1e-5);
+        Assert.assertEquals(17, testStatistic.mannWhitneyUMin(x, y), 1e-10);
+        Assert.assertEquals(0.08641, testStatistic.mannWhitneyUTestMin(x, y), 1e-5);
     }
 
 
@@ -52,14 +52,14 @@ public class MannWhitneyUTestTest {
         /* Samples must be present, i.e. length > 0
          */
         try {
-            testStatistic.mannWhiteneyUTestMax(new double[] { }, new double[] { 1.0 });
+            testStatistic.mannWhiteneyUTestMin(new double[] { }, new double[] { 1.0 });
             Assert.fail("x does not contain samples (exact), NoDataException expected");
         } catch (NoDataException ex) {
             // expected
         }
 
         try {
-            testStatistic.mannWhiteneyUTestMax(new double[] { 1.0 }, new double[] { });
+            testStatistic.mannWhiteneyUTestMin(new double[] { 1.0 }, new double[] { });
             Assert.fail("y does not contain samples (exact), NoDataException expected");
         } catch (NoDataException ex) {
             // expected
@@ -69,14 +69,14 @@ public class MannWhitneyUTestTest {
          * x and y is null
          */
         try {
-            testStatistic.mannWhiteneyUTestMax(null, null);
+            testStatistic.mannWhiteneyUTestMin(null, null);
             Assert.fail("x and y is null (exact), NullArgumentException expected");
         } catch (NullArgumentException ex) {
             // expected
         }
 
         try {
-            testStatistic.mannWhiteneyUTestMax(null, null);
+            testStatistic.mannWhiteneyUTestMin(null, null);
             Assert.fail("x and y is null (asymptotic), NullArgumentException expected");
         } catch (NullArgumentException ex) {
             // expected
@@ -86,14 +86,14 @@ public class MannWhitneyUTestTest {
          * x or y is null
          */
         try {
-            testStatistic.mannWhiteneyUTestMax(null, new double[] { 1.0 });
+            testStatistic.mannWhiteneyUTestMin(null, new double[] { 1.0 });
             Assert.fail("x is null (exact), NullArgumentException expected");
         } catch (NullArgumentException ex) {
             // expected
         }
 
         try {
-            testStatistic.mannWhiteneyUTestMax(new double[] { 1.0 }, null);
+            testStatistic.mannWhiteneyUTestMin(new double[] { 1.0 }, null);
             Assert.fail("y is null (exact), NullArgumentException expected");
         } catch (NullArgumentException ex) {
             // expected
@@ -108,7 +108,7 @@ public class MannWhitneyUTestTest {
             d1[i] = 2 * i;
             d2[i] = 2 * i + 1;
         }
-        double result = testStatistic.mannWhiteneyUTestMax(d1, d2);
+        double result = testStatistic.mannWhiteneyUTestMin(d1, d2);
         Assert.assertTrue(result > 0.1);
     }
 
@@ -121,7 +121,7 @@ public class MannWhitneyUTestTest {
             d1[i] = i;
             d2[i] = i;
         }
-        double result = testStatistic.mannWhiteneyUTestMax(d1, d2);
+        double result = testStatistic.mannWhiteneyUTestMin(d1, d2);
         Assert.assertTrue(result == 1.0);
     }
 }


### PR DESCRIPTION
1. According to Nikos Katsipoulakis, the Mann-Whiteney U Tests should return the minimum of U1 and U2. It currently returns the maximum.

2. The latest version of commons-math is 3.6.1, not 3.5, updated the README to reflect this.