### PR TITLE
[MATH-1617]Fix hashcode not updated with equals.

### DIFF
--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BigReal.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BigReal.java
@@ -323,7 +323,7 @@ public class BigReal implements FieldElement<BigReal>, Comparable<BigReal>, Seri
     /** {@inheritDoc} */
     @Override
     public int hashCode() {
-        return d.hashCode();
+        return Double.hashCode(d.doubleValue());
     }
 
     /** {@inheritDoc} */

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/BigRealTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/BigRealTest.java
@@ -178,6 +178,7 @@ public class BigRealTest {
         BigReal oneWithScaleOne = new BigReal(new BigDecimal("1.0"));
         BigReal oneWithScaleTwo = new BigReal(new BigDecimal("1.00"));
         Assert.assertEquals(oneWithScaleOne, oneWithScaleTwo);
+        Assert.assertEquals(oneWithScaleOne.hashCode(), oneWithScaleTwo.hashCode());
     }
 
     @Test


### PR DESCRIPTION
Related ticket: https://issues.apache.org/jira/browse/MATH-1617#
Previous provided fix on changing `BigReal#equals` but `hashcode` is not updated, providing inconsistent result.