### PR TITLE
Fix wrong documentation for exceptions in StatUtils and add missing

### DIFF
--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/StatUtils.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/StatUtils.java
@@ -782,7 +782,8 @@ public final class StatUtils {
      *
      * @param sample input data
      * @return array of array of the most frequently occurring element(s) sorted in ascending order.
-     * @throws MathIllegalArgumentException if the indices are invalid or the array is null
+     * @throws MathIllegalArgumentException if the indices are invalid
+     * @throws NullArgumentException if the array is null
      * @since 3.3
      */
     public static double[] mode(double[] sample) throws MathIllegalArgumentException {
@@ -812,7 +813,9 @@ public final class StatUtils {
      * @param begin index (0-based) of the first array element to include
      * @param length the number of elements to include
      * @return array of array of the most frequently occurring element(s) sorted in ascending order.
-     * @throws MathIllegalArgumentException if the indices are invalid or the array is null
+     * @throws MathIllegalArgumentException if the indices are invalid
+     * @throws NullArgumentException if the array is null
+     * @throws NotPositiveException if {@code begin < 0} or {@code length < 0}
      * @since 3.3
      */
     public static double[] mode(double[] sample, final int begin, final int length) {

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/StatUtilsTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/StatUtilsTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.math4.legacy.stat;
 
 import org.apache.commons.math4.legacy.TestUtils;
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
+import org.apache.commons.math4.legacy.exception.NotPositiveException;
 import org.apache.commons.math4.legacy.exception.NullArgumentException;
 import org.apache.commons.math4.legacy.stat.descriptive.DescriptiveStatistics;
 import org.apache.commons.math4.core.jdkmath.JdkMath;
@@ -545,6 +546,30 @@ public final class StatUtilsTest {
             StatUtils.mode(nullArray);
             Assert.fail("Expecting NullArgumentException");
         } catch (NullArgumentException ex) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testMode3ArgumentsExceptions() {
+        final double[] nullArray = null;
+        try {
+            StatUtils.mode(nullArray, 0, 1);
+            Assert.fail("Expecting NullArgumentException");
+        } catch (NullArgumentException ex) {
+            // Expected
+        }
+        final double[] emptyArray = {};
+        try { // begin negative
+            StatUtils.mode(emptyArray, -1, 0);
+            Assert.fail("Expecting NotPositiveException");
+        } catch (NotPositiveException ex) {
+            // Expected
+        }
+        try { // length negative
+            StatUtils.mode(emptyArray, 0, -1);
+            Assert.fail("Expecting NotPositiveException");
+        } catch (NotPositiveException ex) {
             // Expected
         }
     }


### PR DESCRIPTION
Hello! I found that a couple of methods in `StatUtils` were _wrongly_ documenting in javadoc to throw `MathIllegalArgumentException` for null arrays, instead of `NullArgumentException`.
I took the opportunity to add documentation and tests for `NotPositiveException` for `mode(double[], int, int)`.

As I mentioned in #206, I'm happy to submit more pull requests with similar fixes/additions to the documentation if it's something welcomed by the project. 

---

On another note, I found a few methods on `Variance` (called by `StatUtils`) that will throw `NullPointerException` (null dereference), instead of `NullArgumentException`. I'm also happy to submit a pull request fixing those. The fix is very easy but will entail other documentation modifications, and likely some test changes/additions.

https://github.com/apache/commons-math/blob/57dda85533fbac18389a3ddc70e3640aa4484a91/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/descriptive/moment/Variance.java#L368-L371

https://github.com/apache/commons-math/blob/57dda85533fbac18389a3ddc70e3640aa4484a91/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/descriptive/moment/Variance.java#L452-L454
