### PR TITLE
MATH-1647: fixed HaltonSequenceGenerator.skipTo() method to throw Not…

### DIFF
--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/random/HaltonSequenceGenerator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/random/HaltonSequenceGenerator.java
@@ -19,6 +19,7 @@ package org.apache.commons.math4.legacy.random;
 import java.util.function.Supplier;
 
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
+import org.apache.commons.math4.legacy.exception.NotPositiveException;
 import org.apache.commons.math4.legacy.exception.NullArgumentException;
 import org.apache.commons.math4.legacy.exception.OutOfRangeException;
 
@@ -165,6 +166,10 @@ public class HaltonSequenceGenerator implements Supplier<double[]> {
      * @throws org.apache.commons.math4.legacy.exception.NotPositiveException NotPositiveException if index &lt; 0
      */
     public double[] skipTo(final int index) {
+        if (index < 0) {
+            throw new NotPositiveException(index);
+        }
+
         count = index;
         return get();
     }

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/HaltonSequenceGeneratorTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/HaltonSequenceGeneratorTest.java
@@ -135,7 +135,7 @@ public class HaltonSequenceGeneratorTest {
     @Test
     public void testSkipToNegative() {
         try {
-            generator.skipTo((-4584));
+            generator.skipTo(-4584);
             Assert.fail("an exception should have been thrown");
         } catch (NotPositiveException e) {
             // expected

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/HaltonSequenceGeneratorTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/HaltonSequenceGeneratorTest.java
@@ -133,7 +133,7 @@ public class HaltonSequenceGeneratorTest {
     }
 
     @Test
-    public void testSkipToNegativeShouldThrow() {
+    public void testSkipToNegative() {
         try {
             generator.skipTo((-4584));
             Assert.fail("an exception should have been thrown");

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/HaltonSequenceGeneratorTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/HaltonSequenceGeneratorTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.math4.legacy.random;
 
 import org.junit.Assert;
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
+import org.apache.commons.math4.legacy.exception.NotPositiveException;
 import org.apache.commons.math4.legacy.exception.NullArgumentException;
 import org.apache.commons.math4.legacy.exception.OutOfRangeException;
 import org.junit.Before;
@@ -131,4 +132,13 @@ public class HaltonSequenceGeneratorTest {
         }
     }
 
+    @Test
+    public void testSkipToNegativeShouldThrow() {
+        try {
+            generator.skipTo((-4584));
+            Assert.fail("an exception should have been thrown");
+        } catch (NotPositiveException e) {
+            // expected
+        }
+    }
 }


### PR DESCRIPTION
…PositiveException when index is less than 0
jira issue: https://issues.apache.org/jira/browse/MATH-1647