### PR TITLE
Include the initial point in the minimum number of points to form a c…

### DIFF
--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ml/clustering/DBSCANClusterer.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ml/clustering/DBSCANClusterer.java
@@ -140,7 +140,7 @@ public class DBSCANClusterer<T extends Clusterable> extends Clusterer<T> {
                 continue;
             }
             final List<T> neighbors = getNeighbors(point, points);
-            if (neighbors.size() >= minPts) {
+            if (neighbors.size() >= minPts - 1) {
                 // DBSCAN does not care about center points
                 final Cluster<T> cluster = new Cluster<>();
                 clusters.add(expandCluster(cluster, point, neighbors, points, visited));
@@ -178,7 +178,7 @@ public class DBSCANClusterer<T extends Clusterable> extends Clusterer<T> {
             // only check non-visited points
             if (pStatus == null) {
                 final List<T> currentNeighbors = getNeighbors(current, points);
-                if (currentNeighbors.size() >= minPts) {
+                if (currentNeighbors.size() >= minPts - 1) {
                     seeds = merge(seeds, currentNeighbors);
                 }
             }

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/ml/clustering/DBSCANClustererTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/ml/clustering/DBSCANClustererTest.java
@@ -160,6 +160,43 @@ public class DBSCANClustererTest {
     }
 
     @Test
+    public void minPtsIncludesInitialPoint() {
+        final DoublePoint[] points = {
+                new DoublePoint(new double[] { 4.0, 5.0 }),
+                new DoublePoint(new double[] { 6.0, 5.0 }),
+                new DoublePoint(new double[] { 5.0, 5.0 }),
+                new DoublePoint(new double[] { 5.0, 4.0 }),
+                new DoublePoint(new double[] { 5.0, 6.0 })
+        };
+
+        final DBSCANClusterer<DoublePoint> clusterer = new DBSCANClusterer<>(1.0, 5);
+        final List<Cluster<DoublePoint>> clusters = clusterer.cluster(Arrays.asList(points));
+
+        Assert.assertEquals(1, clusters.size());
+    }
+
+    @Test
+    public void minPtsIncludesSeedPoint() {
+        final DoublePoint[] points = {
+                new DoublePoint(new double[] { 4.0, 5.0 }),
+                new DoublePoint(new double[] { 6.0, 5.0 }),
+                new DoublePoint(new double[] { 5.0, 5.0 }),
+                new DoublePoint(new double[] { 5.0, 4.0 }),
+                new DoublePoint(new double[] { 5.0, 6.0 }),
+                new DoublePoint(new double[]{ 5.8090169943749475, 6.587785252292473 }),
+                new DoublePoint(new double[]{ 5.3090169943749475, 6.951056516295154 }),
+                new DoublePoint(new double[]{ 4.6909830056250525, 6.951056516295154 }),
+                new DoublePoint(new double[]{ 4.1909830056250525, 6.587785252292473 }),
+        };
+
+        final DBSCANClusterer<DoublePoint> clusterer = new DBSCANClusterer<>(1.0, 5);
+        final List<Cluster<DoublePoint>> clusters = clusterer.cluster(Arrays.asList(points));
+
+        Assert.assertEquals(1, clusters.size());
+        Assert.assertEquals(9, clusters.get(0).getPoints().size());
+    }
+
+    @Test
     public void testGetEps() {
         final DBSCANClusterer<DoublePoint> transformer = new DBSCANClusterer<>(2.0, 5);
         Assert.assertEquals(2.0, transformer.getEps(), 0.0);


### PR DESCRIPTION
DBSCAN requires a minimum number of points to form a cluster. The current implementation only forms a cluster if the number of neighbours of a chosen point >= the minimum number of points. The change accounts for the initial point.