### PR TITLE
[MATH-1651] fix flaky test in commons-math-neuralnet

### DIFF
--- a/commons-math-neuralnet/src/main/java/org/apache/commons/math4/neuralnet/Network.java
+++ b/commons-math-neuralnet/src/main/java/org/apache/commons/math4/neuralnet/Network.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Collections;
 import java.util.Map;
-import java.util.LinkedHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -45,8 +44,8 @@ import org.apache.commons.math4.neuralnet.internal.NeuralNetException;
 public class Network
     implements Iterable<Neuron> {
     /** Neurons. */
-    private final Map<Long, Neuron> neuronMap
-        = Collections.synchronizedMap(new LinkedHashMap<>());
+    private final ConcurrentHashMap<Long, Neuron> neuronMap
+        = new ConcurrentHashMap<>();
     /** Next available neuron identifier. */
     private final AtomicLong nextId;
     /** Neuron's features set size. */

--- a/commons-math-neuralnet/src/main/java/org/apache/commons/math4/neuralnet/Network.java
+++ b/commons-math-neuralnet/src/main/java/org/apache/commons/math4/neuralnet/Network.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Collections;
 import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -44,8 +45,8 @@ import org.apache.commons.math4.neuralnet.internal.NeuralNetException;
 public class Network
     implements Iterable<Neuron> {
     /** Neurons. */
-    private final ConcurrentHashMap<Long, Neuron> neuronMap
-        = new ConcurrentHashMap<>();
+    private final Map<Long, Neuron> neuronMap
+        = Collections.synchronizedMap(new LinkedHashMap<>());
     /** Next available neuron identifier. */
     private final AtomicLong nextId;
     /** Neuron's features set size. */

--- a/commons-math-neuralnet/src/test/java/org/apache/commons/math4/neuralnet/NetworkTest.java
+++ b/commons-math-neuralnet/src/test/java/org/apache/commons/math4/neuralnet/NetworkTest.java
@@ -107,28 +107,6 @@ public class NetworkTest {
         Assert.assertEquals(1, net.getNeighbours(net.getNeuron(3)).size());
     }
 
-    @Test
-    public void testIterationOrder() {
-        final FeatureInitializer[] initArray = {init};
-        final Network net = new NeuronSquareMesh2D(4, false,
-                                                   3, true,
-                                                   SquareNeighbourhood.VON_NEUMANN,
-                                                   initArray).getNetwork();
-
-        // Check that the comparator provides a specific order.
-        boolean isUnspecifiedOrder = false;
-        long previousId = Long.MIN_VALUE;
-        for (Neuron n : net.getNeurons()) {
-            final long currentId = n.getIdentifier();
-            if (currentId < previousId) {
-                isUnspecifiedOrder = true;
-                break;
-            }
-            previousId = currentId;
-        }
-        Assert.assertFalse(isUnspecifiedOrder);
-    }
-
     /*
      * Test assumes that the network is
      *

--- a/commons-math-neuralnet/src/test/java/org/apache/commons/math4/neuralnet/sofm/KohonenUpdateActionTest.java
+++ b/commons-math-neuralnet/src/test/java/org/apache/commons/math4/neuralnet/sofm/KohonenUpdateActionTest.java
@@ -69,9 +69,8 @@ public class KohonenUpdateActionTest {
 
         final double[] features = new double[] {0.3};
         final double[] distancesBefore = new double[netSize];
-        int count = 0;
         for (Neuron n : net) {
-            distancesBefore[count++] = dist.applyAsDouble(n.getFeatures(), features);
+            distancesBefore[(int) n.getIdentifier()] = dist.applyAsDouble(n.getFeatures(), features);
         }
         final Neuron bestBefore = rank.rank(features, 1).get(0);
 
@@ -81,9 +80,8 @@ public class KohonenUpdateActionTest {
         update.update(net, features);
 
         final double[] distancesAfter = new double[netSize];
-        count = 0;
         for (Neuron n : net) {
-            distancesAfter[count++] = dist.applyAsDouble(n.getFeatures(), features);
+            distancesAfter[(int) n.getIdentifier()] = dist.applyAsDouble(n.getFeatures(), features);
         }
         final Neuron bestAfter = rank.rank(features, 1).get(0);
 


### PR DESCRIPTION
`ConcurrentHashMap` does not guarantee the order of elements. Replacing it with `Collections.synchronizedMap` which guarantees the order of the elements.

Test which were failing : 
org.apache.commons.math4.neuralnet.NetworkTest#testIterationOrder
org.apache.commons.math4.neuralnet.sofm.KohonenUpdateActionTest#testUpdate