### PR TITLE
Use same artifactId prefix as modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,10 @@ Apache Commons Math
 [![Build Status](https://github.com/apache/commons-math/actions/workflows/maven.yml/badge.svg)](https://github.com/apache/commons-math/actions/workflows/maven.yml)
 [![Coverage Status](https://codecov.io/gh/apache/commons-math/branch/master/graph/badge.svg)](https://app.codecov.io/gh/apache/commons-math)
 <!--
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-math-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-math-parent/)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-math4-parent/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.apache.commons/commons-math4-parent/)
 -->
 <!--
-[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-math-parent/4.0.svg)](https://javadoc.io/doc/org.apache.commons/commons-math-parent/4.0)
+[![Javadocs](https://javadoc.io/badge/org.apache.commons/commons-math4-parent/4.0.svg)](https://javadoc.io/doc/org.apache.commons/commons-math4-parent/4.0)
 -->
 
 "Commons Math" is undergoing major changes towards the next release (4.0):
@@ -81,7 +81,7 @@ Alternatively, you can pull it from the central Maven repositories:
 ```xml
 <dependency>
   <groupId>org.apache.commons</groupId>
-  <artifactId>commons-math-parent</artifactId>
+  <artifactId>commons-math4-parent</artifactId>
   <version>4.0</version>
 </dependency>
 ```

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 
               Apache Commons Math 4.0-beta1 RELEASE NOTES
 
-The Apache Commons Math team is pleased to announce the release of commons-math-parent-4.0-beta1
+The Apache Commons Math team is pleased to announce the release of commons-math4-parent-4.0-beta1
 
 The Apache Commons Math project is a library of lightweight mathematics
     and statistics components addressing common practical problems.

--- a/commons-math-core/pom.xml
+++ b/commons-math-core/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-math-parent</artifactId>
+    <artifactId>commons-math4-parent</artifactId>
     <version>4.0-SNAPSHOT</version>
   </parent>
 

--- a/commons-math-docs/pom.xml
+++ b/commons-math-docs/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-math-parent</artifactId>
+    <artifactId>commons-math4-parent</artifactId>
     <version>4.0-SNAPSHOT</version>
   </parent>
 

--- a/commons-math-examples/pom.xml
+++ b/commons-math-examples/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-math-parent</artifactId>
+    <artifactId>commons-math4-parent</artifactId>
     <version>4.0-SNAPSHOT</version>
   </parent>
 

--- a/commons-math-legacy-core/pom.xml
+++ b/commons-math-legacy-core/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-math-parent</artifactId>
+    <artifactId>commons-math4-parent</artifactId>
     <version>4.0-SNAPSHOT</version>
   </parent>
 

--- a/commons-math-legacy-exception/pom.xml
+++ b/commons-math-legacy-exception/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-math-parent</artifactId>
+    <artifactId>commons-math4-parent</artifactId>
     <version>4.0-SNAPSHOT</version>
   </parent>
 

--- a/commons-math-legacy/pom.xml
+++ b/commons-math-legacy/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-math-parent</artifactId>
+    <artifactId>commons-math4-parent</artifactId>
     <version>4.0-SNAPSHOT</version>
   </parent>
 

--- a/commons-math-neuralnet/pom.xml
+++ b/commons-math-neuralnet/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-math-parent</artifactId>
+    <artifactId>commons-math4-parent</artifactId>
     <version>4.0-SNAPSHOT</version>
   </parent>
 

--- a/commons-math-transform/pom.xml
+++ b/commons-math-transform/pom.xml
@@ -20,7 +20,7 @@
 
   <parent>
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-math-parent</artifactId>
+    <artifactId>commons-math4-parent</artifactId>
     <version>4.0-SNAPSHOT</version>
   </parent>
 

--- a/dist-archive/pom.xml
+++ b/dist-archive/pom.xml
@@ -22,7 +22,7 @@ under the License.
 
   <parent>
     <groupId>org.apache.commons</groupId>
-    <artifactId>commons-math-parent</artifactId>
+    <artifactId>commons-math4-parent</artifactId>
     <version>4.0-SNAPSHOT</version>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <version>59</version>
   </parent>
 
-  <artifactId>commons-math-parent</artifactId>
+  <artifactId>commons-math4-parent</artifactId>
   <version>4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Apache Commons Math</name>


### PR DESCRIPTION
Changing the artifactId would normally require a corresponding change of package. But in this case, the parent does not include any Java code, so we should be OK.

Raising as a PR just in case anyone has concerns