### PR TITLE
Set to default strategies if null is given

### DIFF
--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/ranking/NaturalRanking.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/ranking/NaturalRanking.java
@@ -158,8 +158,8 @@ public class NaturalRanking implements RankingAlgorithm {
     private NaturalRanking(NaNStrategy nanStrategy,
                            TiesStrategy tiesStrategy,
                            UniformRandomProvider random) {
-        this.nanStrategy = nanStrategy;
-        this.tiesStrategy = tiesStrategy;
+        this.nanStrategy = nanStrategy != null ? nanStrategy : DEFAULT_NAN_STRATEGY;
+        this.tiesStrategy = tiesStrategy != null ? tiesStrategy : DEFAULT_TIES_STRATEGY;
         this.random = random;
     }
 

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/ranking/NaturalRankingTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/ranking/NaturalRankingTest.java
@@ -279,4 +279,15 @@ public class NaturalRankingTest {
         double[] ranks = ranking.rank(data);
         TestUtils.assertEquals(data, ranks, 0d);
     }
+
+    /**
+     * Tests NaturalRanking constructor with null strategies as inputs.
+     * These should be switched to the default strategies.
+     */
+    @Test
+    public void testNullStrategies() {
+        NaturalRanking ranking = new NaturalRanking((NaNStrategy) null, (TiesStrategy) null);
+        Assert.assertEquals(ranking.getNanStrategy(), NaturalRanking.DEFAULT_NAN_STRATEGY);
+        Assert.assertEquals(ranking.getTiesStrategy(), NaturalRanking.DEFAULT_TIES_STRATEGY);
+    }
 }


### PR DESCRIPTION
In the current implementation, it is possible to set the `nanStrategy` and `tiesStrategy` of `NaturalRanking` to `null`, even though they will inevitably throw NPEs upon any calls to `rank` or `resolveTie`. This commit modifies the constructor such that if `null` is given to either of the strategies, then they are set to the default strategies.