### PR TITLE
Upgrade Java 8 to Java 17

### DIFF
--- a/commons-math-examples/examples-sofm/tsp/src/main/java/org/apache/commons/math4/examples/sofm/tsp/City.java
+++ b/commons-math-examples/examples-sofm/tsp/src/main/java/org/apache/commons/math4/examples/sofm/tsp/City.java
@@ -155,8 +155,7 @@ public class City {
     /** {@inheritDoc} */
     @Override
     public boolean equals(Object o) {
-        if (o instanceof City) {
-            final City other = (City) o;
+        if (o instanceof City other) {
             return x == other.x &&
                 y == other.y;
         }

--- a/commons-math-legacy-core/src/main/java/org/apache/commons/math4/legacy/core/dfp/Dfp.java
+++ b/commons-math-legacy-core/src/main/java/org/apache/commons/math4/legacy/core/dfp/Dfp.java
@@ -894,8 +894,7 @@ public class Dfp implements RealFieldElement<Dfp> {
     @Override
     public boolean equals(final Object other) {
 
-        if (other instanceof Dfp) {
-            final Dfp x = (Dfp) other;
+        if (other instanceof Dfp x) {
             if (isNaN() || x.isNaN() || field.getRadixDigits() != x.field.getRadixDigits()) {
                 return false;
             }

--- a/commons-math-legacy-core/src/test/java/org/apache/commons/math4/legacy/core/jdkmath/AccurateMathStrictComparisonTest.java
+++ b/commons-math-legacy-core/src/test/java/org/apache/commons/math4/legacy/core/jdkmath/AccurateMathStrictComparisonTest.java
@@ -107,8 +107,7 @@ public class AccurateMathStrictComparisonTest {
         String format = null;
         long actL = 0;
         long expL = 0;
-        if (expected instanceof Double) {
-            Double exp = (Double) expected;
+        if (expected instanceof Double exp) {
             Double act = (Double) actual;
             if (isNumber(exp) && isNumber(act) && exp != 0) { // show difference as hex
                 actL = Double.doubleToLongBits(act);
@@ -121,8 +120,7 @@ public class AccurateMathStrictComparisonTest {
                 }
                 format = "%016x";
             }
-        } else if (expected instanceof Float) {
-            Float exp = (Float) expected;
+        } else if (expected instanceof Float exp) {
             Float act = (Float) actual;
             if (isNumber(exp) && isNumber(act) && exp != 0) { // show difference as hex
                 actL = Float.floatToIntBits(act);
@@ -143,13 +141,13 @@ public class AccurateMathStrictComparisonTest {
         }
         sb.append(") expected ");
         if (format != null) {
-            sb.append(String.format(format, expL));
+            sb.append(format.formatted(expL));
         } else {
             sb.append(expected);
         }
         sb.append(" actual ");
         if (format != null) {
-            sb.append(String.format(format, actL));
+            sb.append(format.formatted(actL));
         } else {
             sb.append(actual);
         }

--- a/commons-math-legacy-core/src/test/java/org/apache/commons/math4/legacy/core/jdkmath/AccurateMathTest.java
+++ b/commons-math-legacy-core/src/test/java/org/apache/commons/math4/legacy/core/jdkmath/AccurateMathTest.java
@@ -675,11 +675,11 @@ public class AccurateMathTest {
         if (numerator == 0) {
             // Exact including the sign.
             Assertions.assertEquals(numerator, v,
-                () -> String.format("atan2(%s, %s) should be %s but was %s", y, x, numerator, v));
+                () -> "atan2(%s, %s) should be %s but was %s".formatted(y, x, numerator, v));
         } else {
             final double expected = AccurateMath.PI * numerator / denominator;
             Assertions.assertEquals(expected, v, Precision.EPSILON,
-                () -> String.format("atan2(%s, %s) should be pi * %s / %s", y, x, numerator, denominator));
+                () -> "atan2(%s, %s) should be pi * %s / %s".formatted(y, x, numerator, denominator));
         }
     }
 

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/ConvergenceException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/ConvergenceException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class ConvergenceException extends MathIllegalStateException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 4330003017885151975L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/DimensionMismatchException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/DimensionMismatchException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class DimensionMismatchException extends MathIllegalNumberException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -8415396756375798143L;
     /** Correct dimension. */
     private final int dimension;

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/InsufficientDataException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/InsufficientDataException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -28,6 +30,7 @@ public class InsufficientDataException
     extends MathIllegalArgumentException {
 
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -2629324471511903359L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathArithmeticException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathArithmeticException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -29,6 +31,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class MathArithmeticException extends MathRuntimeException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -6024911025449780478L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathIllegalArgumentException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathIllegalArgumentException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 
 /**
@@ -28,6 +30,7 @@ import org.apache.commons.math4.legacy.exception.util.Localizable;
  */
 public class MathIllegalArgumentException extends MathRuntimeException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -6024911025449780478L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathIllegalNumberException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathIllegalNumberException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 
 /**
@@ -32,6 +34,7 @@ public class MathIllegalNumberException extends MathIllegalArgumentException {
     protected static final Integer INTEGER_ZERO = Integer.valueOf(0);
 
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -7447085893598031110L;
 
     /** Requested. */

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathIllegalStateException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathIllegalStateException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -28,6 +30,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class MathIllegalStateException extends MathRuntimeException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -6024911025449780478L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathInternalError.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathInternalError.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class MathInternalError extends MathIllegalStateException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -6276776513966934846L;
     /** URL for reporting problems. */
     private static final String REPORT_URL = "https://issues.apache.org/jira/browse/MATH";

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathParseException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathParseException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
 /**
@@ -25,6 +27,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class MathParseException extends MathIllegalStateException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -6024911025449780478L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathRuntimeException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathRuntimeException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.ExceptionContext;
 import org.apache.commons.math4.legacy.exception.util.ExceptionContextProvider;
 import org.apache.commons.math4.legacy.exception.util.Localizable;
@@ -32,6 +34,7 @@ import org.apache.commons.math4.legacy.exception.util.Localizable;
 public class MathRuntimeException extends RuntimeException
     implements ExceptionContextProvider {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 20120926L;
     /** Context. */
     private final ExceptionContext context;

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathUnsupportedOperationException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MathUnsupportedOperationException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -29,6 +31,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class MathUnsupportedOperationException extends MathRuntimeException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -6024911025449780478L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MaxCountExceededException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MaxCountExceededException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class MaxCountExceededException extends MathIllegalStateException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 4330003017885151975L;
     /**
      * Maximum number of evaluations.

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MultiDimensionMismatchException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/MultiDimensionMismatchException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class MultiDimensionMismatchException extends MathIllegalArgumentException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -8415396756375798143L;
 
     /** Wrong dimensions. */

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NoBracketingException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NoBracketingException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NoBracketingException extends MathIllegalArgumentException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -3629324471511904459L;
     /** Lower end of the interval. */
     private final double lo;

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NoDataException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NoDataException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 public class NoDataException extends MathIllegalArgumentException {
 
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -3629324471511904459L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NonMonotonicSequenceException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NonMonotonicSequenceException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
 /**
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NonMonotonicSequenceException extends MathIllegalNumberException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 20210531L;
     /**
      * Whether the sequence should be increasing.

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NotANumberException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NotANumberException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
 /**
@@ -25,6 +27,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NotANumberException extends MathIllegalNumberException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 20120906L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NotFiniteNumberException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NotFiniteNumberException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NotFiniteNumberException extends MathIllegalNumberException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -6100997100383932834L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NotPositiveException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NotPositiveException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 
 /**
@@ -25,6 +27,7 @@ import org.apache.commons.math4.legacy.exception.util.Localizable;
  */
 public class NotPositiveException extends NumberIsTooSmallException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -2250556892093726375L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NotStrictlyPositiveException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NotStrictlyPositiveException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 
 /**
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.Localizable;
 public class NotStrictlyPositiveException extends NumberIsTooSmallException {
 
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -7824848630829852237L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NullArgumentException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NullArgumentException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.ExceptionContext;
 import org.apache.commons.math4.legacy.exception.util.ExceptionContextProvider;
 import org.apache.commons.math4.legacy.exception.util.Localizable;
@@ -38,6 +40,7 @@ public class NullArgumentException extends NullPointerException
     implements ExceptionContextProvider {
 
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 20150225L;
 
     /** Context. */

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NumberIsTooLargeException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NumberIsTooLargeException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NumberIsTooLargeException extends MathIllegalNumberException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 4330003017885151975L;
     /**
      * Higher bound.

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NumberIsTooSmallException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/NumberIsTooSmallException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NumberIsTooSmallException extends MathIllegalNumberException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -6100997100383932834L;
     /**
      * Higher bound.

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/OutOfRangeException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/OutOfRangeException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class OutOfRangeException extends MathIllegalNumberException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 111601815794403609L;
     /** Lower bound. */
     private final Number lo;

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/TooManyEvaluationsException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/TooManyEvaluationsException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
 /**
@@ -25,6 +27,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class TooManyEvaluationsException extends MaxCountExceededException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 4330003017885151975L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/TooManyIterationsException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/TooManyIterationsException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
 /**
@@ -25,6 +27,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class TooManyIterationsException extends MaxCountExceededException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 20121211L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/ZeroException.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/ZeroException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.exception;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 public class ZeroException extends MathIllegalNumberException {
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -1960874856936000015L;
 
     /**

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/util/ArgUtils.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/util/ArgUtils.java
@@ -41,8 +41,8 @@ public final class ArgUtils {
         final List<Object> list = new ArrayList<>();
         if (array != null) {
             for (Object o : array) {
-                if (o instanceof Object[]) {
-                    list.addAll(Arrays.asList(flatten((Object[]) o)));
+                if (o instanceof Object[] objects) {
+                    list.addAll(Arrays.asList(flatten(objects)));
                 } else {
                     list.add(o);
                 }

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/util/DummyLocalizable.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/util/DummyLocalizable.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.legacy.exception.util;
 
+import java.io.Serial;
 import java.util.Locale;
 
 /**
@@ -26,6 +27,7 @@ import java.util.Locale;
 public class DummyLocalizable implements Localizable {
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 8843275624471387299L;
 
     /** Source string. */

--- a/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/util/ExceptionContext.java
+++ b/commons-math-legacy-exception/src/main/java/org/apache/commons/math4/legacy/exception/util/ExceptionContext.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Set;
 import java.util.Map;
 import java.io.IOException;
+import java.io.Serial;
 import java.io.Serializable;
 import java.io.ObjectOutputStream;
 import java.io.ObjectInputStream;
@@ -37,6 +38,7 @@ import java.util.Locale;
  */
 public class ExceptionContext implements Serializable {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -6024911025449780478L;
     /**
      * The throwable to which this context refers to.

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/analysis/differentiation/DerivativeStructure.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/analysis/differentiation/DerivativeStructure.java
@@ -1138,8 +1138,7 @@ public class DerivativeStructure implements RealFieldElement<DerivativeStructure
             return true;
         }
 
-        if (other instanceof DerivativeStructure) {
-            final DerivativeStructure rhs = (DerivativeStructure)other;
+        if (other instanceof DerivativeStructure rhs) {
             return getFreeParameters() == rhs.getFreeParameters() &&
                    getOrder() == rhs.getOrder() &&
                    MathArrays.equals(data, rhs.data);

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/analysis/differentiation/SparseGradient.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/analysis/differentiation/SparseGradient.java
@@ -884,8 +884,7 @@ public final class SparseGradient implements RealFieldElement<SparseGradient> {
             return true;
         }
 
-        if (other instanceof SparseGradient) {
-            final SparseGradient rhs = (SparseGradient)other;
+        if (other instanceof SparseGradient rhs) {
             if (!Precision.equals(value, rhs.value, 1)) {
                 return false;
             }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/distribution/fitting/MultivariateNormalMixtureExpectationMaximization.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/distribution/fitting/MultivariateNormalMixtureExpectationMaximization.java
@@ -430,8 +430,8 @@ public class MultivariateNormalMixtureExpectationMaximization {
                 return true;
             }
 
-            if (other instanceof DataRow) {
-                return MathArrays.equals(row, ((DataRow) other).row);
+            if (other instanceof DataRow dataRow) {
+                return MathArrays.equals(row, dataRow.row);
             }
 
             return false;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/field/linalg/FieldDenseMatrix.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/field/linalg/FieldDenseMatrix.java
@@ -125,8 +125,7 @@ public final class FieldDenseMatrix<T>
         if (this == other) {
             return true;
         } else {
-            if (other instanceof FieldDenseMatrix) {
-                final FieldDenseMatrix<?> m = (FieldDenseMatrix<?>) other;
+            if (other instanceof FieldDenseMatrix<?> m) {
                 return field.equals(m.field) &&
                     rows == m.rows &&
                     columns == m.columns &&

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/genetics/AbstractListChromosome.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/genetics/AbstractListChromosome.java
@@ -101,6 +101,6 @@ public abstract class AbstractListChromosome<T> extends Chromosome {
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        return String.format("(f=%s %s)", getFitness(), getRepresentation());
+        return "(f=%s %s)".formatted(getFitness(), getRepresentation());
     }
 }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/genetics/ChromosomePair.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/genetics/ChromosomePair.java
@@ -61,6 +61,6 @@ public class ChromosomePair {
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        return String.format("(%s,%s)", getFirst(), getSecond());
+        return "(%s,%s)".formatted(getFirst(), getSecond());
     }
 }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/genetics/InvalidRepresentationException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/genetics/InvalidRepresentationException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.genetics;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.util.Localizable;
 public class InvalidRepresentationException extends MathIllegalArgumentException {
 
     /** Serialization version id. */
+    @Serial
     private static final long serialVersionUID = 1L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/genetics/RandomKey.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/genetics/RandomKey.java
@@ -281,7 +281,7 @@ public abstract class RandomKey<T> extends AbstractListChromosome<Double> implem
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        return String.format("(f=%s pi=(%s))", getFitness(), baseSeqPermutation);
+        return "(f=%s pi=(%s))".formatted(getFitness(), baseSeqPermutation);
     }
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/AbstractRealMatrix.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/AbstractRealMatrix.java
@@ -695,8 +695,8 @@ public abstract class AbstractRealMatrix
     @Override
     public RealVector operate(final RealVector v)
         throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            return new ArrayRealVector(operate(((ArrayRealVector) v).getDataRef()), false);
+        if (v instanceof ArrayRealVector vector) {
+            return new ArrayRealVector(operate(vector.getDataRef()), false);
         }
 
         final int nRows = getRowDimension();
@@ -742,8 +742,8 @@ public abstract class AbstractRealMatrix
     /** {@inheritDoc} */
     @Override
     public RealVector preMultiply(final RealVector v) throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            return new ArrayRealVector(preMultiply(((ArrayRealVector) v).getDataRef()), false);
+        if (v instanceof ArrayRealVector vector) {
+            return new ArrayRealVector(preMultiply(vector.getDataRef()), false);
         }
 
         final int nRows = getRowDimension();

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/Array2DRowFieldMatrix.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/Array2DRowFieldMatrix.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.core.Field;
@@ -45,6 +46,7 @@ public class Array2DRowFieldMatrix<T extends FieldElement<T>>
     extends AbstractFieldMatrix<T>
     implements Serializable {
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 7260756672015356458L;
     /** Entries of the matrix. */
     private T[][] data;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/Array2DRowRealMatrix.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/Array2DRowRealMatrix.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
@@ -31,6 +32,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class Array2DRowRealMatrix extends AbstractRealMatrix implements Serializable {
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -1067294169172445528L;
 
     /** Entries of the matrix. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/ArrayFieldVector.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/ArrayFieldVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 
@@ -39,6 +40,7 @@ import org.apache.commons.math4.legacy.core.MathArrays;
  */
 public class ArrayFieldVector<T extends FieldElement<T>> implements FieldVector<T>, Serializable {
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 7648186910365927050L;
 
     /** Entries of the vector. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/ArrayRealVector.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/ArrayRealVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -36,6 +37,7 @@ import org.apache.commons.math4.core.jdkmath.JdkMath;
  */
 public class ArrayRealVector extends RealVector implements Serializable {
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -1097961340710804027L;
     /** Default format. */
     private static final RealVectorFormat DEFAULT_FORMAT = RealVectorFormat.getInstance();
@@ -291,8 +293,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     @Override
     public ArrayRealVector add(RealVector v)
         throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            final double[] vData = ((ArrayRealVector) v).data;
+        if (v instanceof ArrayRealVector vector) {
+            final double[] vData = vector.data;
             final int dim = vData.length;
             checkVectorDimensions(dim);
             ArrayRealVector result = new ArrayRealVector(dim);
@@ -317,8 +319,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     @Override
     public ArrayRealVector subtract(RealVector v)
         throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            final double[] vData = ((ArrayRealVector) v).data;
+        if (v instanceof ArrayRealVector vector) {
+            final double[] vData = vector.data;
             final int dim = vData.length;
             checkVectorDimensions(dim);
             ArrayRealVector result = new ArrayRealVector(dim);
@@ -394,8 +396,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     @Override
     public ArrayRealVector ebeMultiply(RealVector v)
         throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            final double[] vData = ((ArrayRealVector) v).data;
+        if (v instanceof ArrayRealVector vector) {
+            final double[] vData = vector.data;
             final int dim = vData.length;
             checkVectorDimensions(dim);
             ArrayRealVector result = new ArrayRealVector(dim);
@@ -418,8 +420,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     @Override
     public ArrayRealVector ebeDivide(RealVector v)
         throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            final double[] vData = ((ArrayRealVector) v).data;
+        if (v instanceof ArrayRealVector vector) {
+            final double[] vData = vector.data;
             final int dim = vData.length;
             checkVectorDimensions(dim);
             ArrayRealVector result = new ArrayRealVector(dim);
@@ -451,8 +453,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     /** {@inheritDoc} */
     @Override
     public double dotProduct(RealVector v) throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            final double[] vData = ((ArrayRealVector) v).data;
+        if (v instanceof ArrayRealVector vector) {
+            final double[] vData = vector.data;
             checkVectorDimensions(vData.length);
             double dot = 0;
             for (int i = 0; i < data.length; i++) {
@@ -496,8 +498,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     /** {@inheritDoc} */
     @Override
     public double getDistance(RealVector v) throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            final double[] vData = ((ArrayRealVector) v).data;
+        if (v instanceof ArrayRealVector vector) {
+            final double[] vData = vector.data;
             checkVectorDimensions(vData.length);
             double sum = 0;
             for (int i = 0; i < data.length; ++i) {
@@ -520,8 +522,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     @Override
     public double getL1Distance(RealVector v)
         throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            final double[] vData = ((ArrayRealVector) v).data;
+        if (v instanceof ArrayRealVector vector) {
+            final double[] vData = vector.data;
             checkVectorDimensions(vData.length);
             double sum = 0;
             for (int i = 0; i < data.length; ++i) {
@@ -544,8 +546,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     @Override
     public double getLInfDistance(RealVector v)
         throws DimensionMismatchException {
-        if (v instanceof ArrayRealVector) {
-            final double[] vData = ((ArrayRealVector) v).data;
+        if (v instanceof ArrayRealVector vector) {
+            final double[] vData = vector.data;
             checkVectorDimensions(vData.length);
             double max = 0;
             for (int i = 0; i < data.length; ++i) {
@@ -567,8 +569,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     /** {@inheritDoc} */
     @Override
     public RealMatrix outerProduct(RealVector v) {
-        if (v instanceof ArrayRealVector) {
-            final double[] vData = ((ArrayRealVector) v).data;
+        if (v instanceof ArrayRealVector vector) {
+            final double[] vData = vector.data;
             final int m = data.length;
             final int n = vData.length;
             final RealMatrix out = MatrixUtils.createRealMatrix(m, n);
@@ -611,8 +613,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     /** {@inheritDoc} */
     @Override
     public RealVector append(RealVector v) {
-        if (v instanceof ArrayRealVector) {
-            return new ArrayRealVector(this, (ArrayRealVector) v);
+        if (v instanceof ArrayRealVector vector) {
+            return new ArrayRealVector(this, vector);
         }
         return new ArrayRealVector(this, v);
     }
@@ -679,8 +681,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     @Override
     public void setSubVector(int index, RealVector v)
         throws OutOfRangeException {
-        if (v instanceof ArrayRealVector) {
-            setSubVector(index, ((ArrayRealVector) v).data);
+        if (v instanceof ArrayRealVector vector) {
+            setSubVector(index, vector.data);
         } else {
             try {
                 for (int i = index; i < index + v.getDimension(); ++i) {
@@ -845,8 +847,8 @@ public class ArrayRealVector extends RealVector implements Serializable {
     @Override
     public ArrayRealVector combineToSelf(double a, double b, RealVector y)
         throws DimensionMismatchException {
-        if (y instanceof ArrayRealVector) {
-            final double[] yData = ((ArrayRealVector) y).data;
+        if (y instanceof ArrayRealVector vector) {
+            final double[] yData = vector.data;
             checkVectorDimensions(yData.length);
             for (int i = 0; i < this.data.length; i++) {
                 data[i] = a * data[i] + b * yData[i];

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BigReal.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BigReal.java
@@ -17,6 +17,7 @@
 package org.apache.commons.math4.legacy.linear;
 
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -45,6 +46,7 @@ public class BigReal implements FieldElement<BigReal>, Comparable<BigReal>, Seri
     public static final BigReal ONE = new BigReal(BigDecimal.ONE);
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 4984534880991310382L;
 
     /** Underlying BigDecimal. */
@@ -314,8 +316,8 @@ public class BigReal implements FieldElement<BigReal>, Comparable<BigReal>, Seri
             return true;
         }
 
-        if (other instanceof BigReal) {
-            return d.compareTo(((BigReal) other).d) == 0;
+        if (other instanceof BigReal real) {
+            return d.compareTo(real.d) == 0;
         }
         return false;
     }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BigRealField.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BigRealField.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.core.Field;
@@ -33,6 +34,7 @@ import org.apache.commons.math4.legacy.core.FieldElement;
 public final class BigRealField implements Field<BigReal>, Serializable  {
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 4756431066541037559L;
 
     /** Private constructor for the singleton.

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BlockFieldMatrix.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BlockFieldMatrix.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.core.Field;
@@ -74,6 +75,7 @@ public class BlockFieldMatrix<T extends FieldElement<T>> extends AbstractFieldMa
     /** Block size. */
     public static final int BLOCK_SIZE = 36;
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -4602336630143123183L;
     /** Blocks of matrix entries. */
     private final T[][] blocks;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BlockRealMatrix.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/BlockRealMatrix.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Arrays;
 
@@ -71,6 +72,7 @@ public class BlockRealMatrix extends AbstractRealMatrix implements Serializable 
     /** Block size. */
     public static final int BLOCK_SIZE = 52;
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 4991895511313664478L;
     /** Blocks of matrix entries. */
     private final double[][] blocks;
@@ -299,8 +301,8 @@ public class BlockRealMatrix extends AbstractRealMatrix implements Serializable 
     @Override
     public BlockRealMatrix add(final RealMatrix m)
         throws MatrixDimensionMismatchException {
-        if (m instanceof BlockRealMatrix) {
-            return add((BlockRealMatrix) m);
+        if (m instanceof BlockRealMatrix matrix) {
+            return add(matrix);
         }
 
         // safety check
@@ -367,8 +369,8 @@ public class BlockRealMatrix extends AbstractRealMatrix implements Serializable 
     @Override
     public BlockRealMatrix subtract(final RealMatrix m)
         throws MatrixDimensionMismatchException {
-        if (m instanceof BlockRealMatrix) {
-            return subtract((BlockRealMatrix) m);
+        if (m instanceof BlockRealMatrix matrix) {
+            return subtract(matrix);
         }
 
         // safety check
@@ -470,8 +472,8 @@ public class BlockRealMatrix extends AbstractRealMatrix implements Serializable 
     @Override
     public BlockRealMatrix multiply(final RealMatrix m)
         throws DimensionMismatchException {
-        if (m instanceof BlockRealMatrix) {
-            return multiply((BlockRealMatrix) m);
+        if (m instanceof BlockRealMatrix matrix) {
+            return multiply(matrix);
         }
 
         // safety check
@@ -868,8 +870,8 @@ public class BlockRealMatrix extends AbstractRealMatrix implements Serializable 
     @Override
     public void setRowMatrix(final int row, final RealMatrix matrix)
         throws OutOfRangeException, MatrixDimensionMismatchException {
-        if (matrix instanceof BlockRealMatrix) {
-            setRowMatrix(row, (BlockRealMatrix) matrix);
+        if (matrix instanceof BlockRealMatrix realMatrix) {
+            setRowMatrix(row, realMatrix);
         } else {
             super.setRowMatrix(row, matrix);
         }
@@ -952,8 +954,8 @@ public class BlockRealMatrix extends AbstractRealMatrix implements Serializable 
     @Override
     public void setColumnMatrix(final int column, final RealMatrix matrix)
         throws OutOfRangeException, MatrixDimensionMismatchException {
-        if (matrix instanceof BlockRealMatrix) {
-            setColumnMatrix(column, (BlockRealMatrix) matrix);
+        if (matrix instanceof BlockRealMatrix realMatrix) {
+            setColumnMatrix(column, realMatrix);
         } else {
             super.setColumnMatrix(column, matrix);
         }
@@ -1026,8 +1028,8 @@ public class BlockRealMatrix extends AbstractRealMatrix implements Serializable 
     @Override
     public void setRowVector(final int row, final RealVector vector)
         throws OutOfRangeException, MatrixDimensionMismatchException {
-        if (vector instanceof ArrayRealVector) {
-            setRow(row, ((ArrayRealVector) vector).getDataRef());
+        if (vector instanceof ArrayRealVector realVector) {
+            setRow(row, realVector.getDataRef());
         } else {
             super.setRowVector(row, vector);
         }
@@ -1060,8 +1062,8 @@ public class BlockRealMatrix extends AbstractRealMatrix implements Serializable 
     @Override
     public void setColumnVector(final int column, final RealVector vector)
         throws OutOfRangeException, MatrixDimensionMismatchException {
-        if (vector instanceof ArrayRealVector) {
-            setColumn(column, ((ArrayRealVector) vector).getDataRef());
+        if (vector instanceof ArrayRealVector realVector) {
+            setColumn(column, realVector.getDataRef());
         } else {
             super.setColumnVector(column, vector);
         }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/DefaultIterativeLinearSolverEvent.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/DefaultIterativeLinearSolverEvent.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathUnsupportedOperationException;
 
 /**
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.MathUnsupportedOperationExcepti
 public class DefaultIterativeLinearSolverEvent extends IterativeLinearSolverEvent {
 
     /** */
+    @Serial
     private static final long serialVersionUID = 20120129L;
 
     /** The right-hand side vector. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/DiagonalMatrix.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/DiagonalMatrix.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
@@ -34,6 +35,7 @@ import org.apache.commons.numbers.core.Precision;
 public class DiagonalMatrix extends AbstractRealMatrix
     implements Serializable {
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 20121229L;
     /** Entries of the diagonal. */
     private final double[] data;
@@ -180,8 +182,8 @@ public class DiagonalMatrix extends AbstractRealMatrix
     @Override
     public RealMatrix multiply(final RealMatrix m)
         throws DimensionMismatchException {
-        if (m instanceof DiagonalMatrix) {
-            return multiply((DiagonalMatrix) m);
+        if (m instanceof DiagonalMatrix matrix) {
+            return multiply(matrix);
         } else {
             MatrixUtils.checkMultiplicationCompatible(this, m);
             final int nRows = m.getRowDimension();
@@ -299,8 +301,8 @@ public class DiagonalMatrix extends AbstractRealMatrix
     @Override
     public RealVector preMultiply(final RealVector v) throws DimensionMismatchException {
         final double[] vectorData;
-        if (v instanceof ArrayRealVector) {
-            vectorData = ((ArrayRealVector) v).getDataRef();
+        if (v instanceof ArrayRealVector vector) {
+            vectorData = vector.getDataRef();
         } else {
             vectorData = v.toArray();
         }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/IllConditionedOperatorException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/IllConditionedOperatorException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -28,6 +30,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 public class IllConditionedOperatorException
     extends MathIllegalArgumentException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -7883263944530490135L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/IterationEvent.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/IterationEvent.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.util.EventObject;
 
 /**
@@ -25,6 +26,7 @@ import java.util.EventObject;
  */
 public class IterationEvent extends EventObject {
     /** */
+    @Serial
     private static final long serialVersionUID = 20120128L;
 
     /** The number of iterations performed so far. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/IterativeLinearSolverEvent.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/IterativeLinearSolverEvent.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathUnsupportedOperationException;
 
 /**
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.MathUnsupportedOperationExcepti
 public abstract class IterativeLinearSolverEvent
     extends IterationEvent {
     /** Serialization identifier. */
+    @Serial
     private static final long serialVersionUID = 20120129L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/JacobiPreconditioner.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/JacobiPreconditioner.java
@@ -63,8 +63,7 @@ public class JacobiPreconditioner extends RealLinearOperator {
             throw new NonSquareOperatorException(a.getRowDimension(), n);
         }
         final double[] diag = new double[n];
-        if (a instanceof AbstractRealMatrix) {
-            final AbstractRealMatrix m = (AbstractRealMatrix) a;
+        if (a instanceof AbstractRealMatrix m) {
             for (int i = 0; i < n; i++) {
                 diag[i] = m.getEntry(i, i);
             }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/MatrixDimensionMismatchException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/MatrixDimensionMismatchException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MultiDimensionMismatchException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class MatrixDimensionMismatchException extends MultiDimensionMismatchException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -8415396756375798143L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/MatrixUtils.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/MatrixUtils.java
@@ -1000,8 +1000,8 @@ public final class MatrixUtils {
                                                matrix.getColumnDimension());
         }
 
-        if (matrix instanceof DiagonalMatrix) {
-            return ((DiagonalMatrix) matrix).inverse(threshold);
+        if (matrix instanceof DiagonalMatrix diagonalMatrix) {
+            return diagonalMatrix.inverse(threshold);
         } else {
             QRDecomposition decomposition = new QRDecomposition(matrix, threshold);
             return decomposition.getSolver().getInverse();

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonPositiveDefiniteMatrixException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonPositiveDefiniteMatrixException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.NumberIsTooSmallException;
 import org.apache.commons.math4.legacy.exception.util.ExceptionContext;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NonPositiveDefiniteMatrixException extends NumberIsTooSmallException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 1641613838113738061L;
     /** Index (diagonal element). */
     private final int index;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonPositiveDefiniteOperatorException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonPositiveDefiniteOperatorException.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -34,6 +36,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 public class NonPositiveDefiniteOperatorException
     extends MathIllegalArgumentException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 917034489420549847L;
 
     /** Creates a new instance of this class. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonSelfAdjointOperatorException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonSelfAdjointOperatorException.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -37,6 +39,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 public class NonSelfAdjointOperatorException
     extends MathIllegalArgumentException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 1784999305030258247L;
 
     /** Creates a new instance of this class. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonSquareMatrixException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonSquareMatrixException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NonSquareMatrixException extends DimensionMismatchException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -660069396594485772L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonSquareOperatorException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonSquareOperatorException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NonSquareOperatorException extends DimensionMismatchException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -4145007524150846242L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonSymmetricMatrixException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/NonSymmetricMatrixException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NonSymmetricMatrixException extends MathIllegalArgumentException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -7518495577824189882L;
     /** Row. */
     private final int row;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/OpenIntToDoubleHashMap.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/OpenIntToDoubleHashMap.java
@@ -21,6 +21,7 @@ import org.apache.commons.math4.core.jdkmath.JdkMath;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ConcurrentModificationException;
 import java.util.NoSuchElementException;
@@ -47,6 +48,7 @@ class OpenIntToDoubleHashMap implements Serializable { // Not in public API.
     protected static final byte REMOVED = 2;
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -3646337053166149105L;
 
     /** Load factor for the map. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/OpenIntToFieldHashMap.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/OpenIntToFieldHashMap.java
@@ -18,6 +18,7 @@ package org.apache.commons.math4.legacy.linear;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.Serial;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.ConcurrentModificationException;
@@ -50,6 +51,7 @@ class OpenIntToFieldHashMap<T extends FieldElement<T>> implements Serializable {
     protected static final byte REMOVED = 2;
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -9179080286849120720L;
 
     /** Load factor for the map. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/OpenMapRealMatrix.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/OpenMapRealMatrix.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
@@ -39,6 +40,7 @@ import org.apache.commons.math4.legacy.exception.OutOfRangeException;
 public class OpenMapRealMatrix extends AbstractRealMatrix
     implements SparseRealMatrix, Serializable {
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -5962461716457143437L;
     /** Number of rows of the matrix. */
     private final int rows;
@@ -133,8 +135,8 @@ public class OpenMapRealMatrix extends AbstractRealMatrix
     @Override
     public OpenMapRealMatrix subtract(final RealMatrix m)
         throws MatrixDimensionMismatchException {
-        if (m instanceof OpenMapRealMatrix) {
-            return subtract((OpenMapRealMatrix) m);
+        if (m instanceof OpenMapRealMatrix matrix) {
+            return subtract(matrix);
         }
         return (OpenMapRealMatrix) super.subtract(m);
     }
@@ -172,8 +174,8 @@ public class OpenMapRealMatrix extends AbstractRealMatrix
     @Override
     public RealMatrix multiply(final RealMatrix m)
         throws DimensionMismatchException, NumberIsTooLargeException {
-        if (m instanceof OpenMapRealMatrix) {
-            return multiply((OpenMapRealMatrix) m);
+        if (m instanceof OpenMapRealMatrix matrix) {
+            return multiply(matrix);
         }
 
         MatrixUtils.checkMultiplicationCompatible(this, m);

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/OpenMapRealVector.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/OpenMapRealVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
@@ -44,6 +45,7 @@ public class OpenMapRealVector extends SparseRealVector
     /** Default Tolerance for having a value considered zero. */
     public static final double DEFAULT_ZERO_TOLERANCE = 1.0e-12;
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 8772222695580707260L;
     /** Entries of the vector. */
     private final OpenIntToDoubleHashMap entries;
@@ -233,8 +235,8 @@ public class OpenMapRealVector extends SparseRealVector
     public RealVector add(RealVector v)
         throws DimensionMismatchException {
         checkVectorDimensions(v.getDimension());
-        if (v instanceof OpenMapRealVector) {
-            return add((OpenMapRealVector) v);
+        if (v instanceof OpenMapRealVector vector) {
+            return add(vector);
         } else {
             return super.add(v);
         }
@@ -285,8 +287,8 @@ public class OpenMapRealVector extends SparseRealVector
     /** {@inheritDoc} */
     @Override
     public OpenMapRealVector append(RealVector v) {
-        if (v instanceof OpenMapRealVector) {
-            return append((OpenMapRealVector) v);
+        if (v instanceof OpenMapRealVector vector) {
+            return append(vector);
         } else {
             final OpenMapRealVector res = new OpenMapRealVector(this, v.getDimension());
             for (int i = 0; i < v.getDimension(); i++) {
@@ -408,8 +410,8 @@ public class OpenMapRealVector extends SparseRealVector
     @Override
     public double getDistance(RealVector v) throws DimensionMismatchException {
         checkVectorDimensions(v.getDimension());
-        if (v instanceof OpenMapRealVector) {
-            return getDistance((OpenMapRealVector) v);
+        if (v instanceof OpenMapRealVector vector) {
+            return getDistance(vector);
         } else {
             return super.getDistance(v);
         }
@@ -459,8 +461,8 @@ public class OpenMapRealVector extends SparseRealVector
     public double getL1Distance(RealVector v)
         throws DimensionMismatchException {
         checkVectorDimensions(v.getDimension());
-        if (v instanceof OpenMapRealVector) {
-            return getL1Distance((OpenMapRealVector) v);
+        if (v instanceof OpenMapRealVector vector) {
+            return getL1Distance(vector);
         } else {
             return super.getL1Distance(v);
         }
@@ -501,8 +503,8 @@ public class OpenMapRealVector extends SparseRealVector
     public double getLInfDistance(RealVector v)
         throws DimensionMismatchException {
         checkVectorDimensions(v.getDimension());
-        if (v instanceof OpenMapRealVector) {
-            return getLInfDistance((OpenMapRealVector) v);
+        if (v instanceof OpenMapRealVector vector) {
+            return getLInfDistance(vector);
         } else {
             return super.getLInfDistance(v);
         }
@@ -614,8 +616,8 @@ public class OpenMapRealVector extends SparseRealVector
     public RealVector subtract(RealVector v)
         throws DimensionMismatchException {
         checkVectorDimensions(v.getDimension());
-        if (v instanceof OpenMapRealVector) {
-            return subtract((OpenMapRealVector) v);
+        if (v instanceof OpenMapRealVector vector) {
+            return subtract(vector);
         } else {
             return super.subtract(v);
         }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/SingularMatrixException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/SingularMatrixException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class SingularMatrixException extends MathIllegalArgumentException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -4206514844735401070L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/SingularOperatorException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/SingularOperatorException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 public class SingularOperatorException
     extends MathIllegalArgumentException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = -476049978595245033L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/SparseFieldVector.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/SparseFieldVector.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.legacy.linear;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.core.Field;
@@ -43,6 +44,7 @@ import org.apache.commons.math4.legacy.core.MathArrays;
  */
 public class SparseFieldVector<T extends FieldElement<T>> implements FieldVector<T>, Serializable {
     /**  Serialization identifier. */
+    @Serial
     private static final long serialVersionUID = 7841233292190413362L;
     /** Field to which the elements belong. */
     private final Field<T> field;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/ContinuousOutputModel.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/ContinuousOutputModel.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.math4.legacy.ode;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -90,6 +91,7 @@ public class ContinuousOutputModel
   implements StepHandler, Serializable {
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -1417964919405031606L;
 
     /** Initial integration time. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/EquationsMapper.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/EquationsMapper.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.math4.legacy.ode;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
@@ -33,6 +34,7 @@ import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
 public class EquationsMapper implements Serializable {
 
     /** Serializable UID. */
+    @Serial
     private static final long serialVersionUID = 20110925L;
 
     /** Index of the first equation element in complete state arrays. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/FieldEquationsMapper.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/FieldEquationsMapper.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.math4.legacy.ode;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 import org.apache.commons.math4.legacy.core.RealFieldElement;
@@ -38,6 +39,7 @@ import org.apache.commons.math4.legacy.core.MathArrays;
 public class FieldEquationsMapper<T extends RealFieldElement<T>> implements Serializable {
 
     /** Serializable UID. */
+    @Serial
     private static final long serialVersionUID = 20151114L;
 
     /** Start indices of the components. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/JacobianMatrices.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/JacobianMatrices.java
@@ -162,8 +162,8 @@ public class JacobianMatrices {
         throws DimensionMismatchException, MismatchedEquations {
 
         // safety checks
-        final FirstOrderDifferentialEquations ode = (jode instanceof MainStateJacobianWrapper) ?
-                                                    ((MainStateJacobianWrapper) jode).ode :
+        final FirstOrderDifferentialEquations ode = (jode instanceof MainStateJacobianWrapper msjw) ?
+                                                    msjw.ode :
                                                     jode;
         if (expandable.getPrimary() != ode) {
             throw new MismatchedEquations();

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/MultistepIntegrator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/MultistepIntegrator.java
@@ -227,8 +227,8 @@ public abstract class MultistepIntegrator extends AdaptiveStepsizeIntegrator {
         // start integration, expecting a InitializationCompletedMarkerException
         try {
 
-            if (starter instanceof AbstractIntegrator) {
-                ((AbstractIntegrator) starter).integrate(getExpandable(), t);
+            if (starter instanceof AbstractIntegrator integrator) {
+                integrator.integrate(getExpandable(), t);
             } else {
                 starter.integrate(new FirstOrderDifferentialEquations() {
 

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/ParameterConfiguration.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/ParameterConfiguration.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.legacy.ode;
 
+import java.io.Serial;
 import java.io.Serializable;
 
 /** Simple container pairing a parameter name with a step in order to compute
@@ -26,6 +27,7 @@ import java.io.Serializable;
 class ParameterConfiguration implements Serializable {
 
     /** Serializable UID. */
+    @Serial
     private static final long serialVersionUID = 2247518849090889379L;
 
     /** Parameter name. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/UnknownParameterException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/UnknownParameterException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.ode;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -27,6 +29,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 public class UnknownParameterException extends MathIllegalArgumentException {
 
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 20120902L;
 
     /** Parameter name. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/ClassicalRungeKuttaStepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/ClassicalRungeKuttaStepInterpolator.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.math4.legacy.ode.nonstiff;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
 
 /**
@@ -55,6 +57,7 @@ class ClassicalRungeKuttaStepInterpolator
     extends RungeKuttaStepInterpolator {
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 20111120L;
 
     /** Simple constructor.

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/DormandPrince54StepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/DormandPrince54StepInterpolator.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.math4.legacy.ode.nonstiff;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.ode.AbstractIntegrator;
 import org.apache.commons.math4.legacy.ode.EquationsMapper;
 import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
@@ -71,6 +73,7 @@ class DormandPrince54StepInterpolator
     private static final double D6 =      69997945.0 /     29380423.0;
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 20111120L;
 
     /** First vector for interpolation. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/DormandPrince853StepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/DormandPrince853StepInterpolator.java
@@ -20,6 +20,7 @@ package org.apache.commons.math4.legacy.ode.nonstiff;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serial;
 
 import org.apache.commons.math4.legacy.exception.MaxCountExceededException;
 import org.apache.commons.math4.legacy.ode.AbstractIntegrator;
@@ -39,6 +40,7 @@ class DormandPrince853StepInterpolator
   extends RungeKuttaStepInterpolator {
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 20111120L;
 
     /** Propagation weights, element 1. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/EulerStepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/EulerStepInterpolator.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.math4.legacy.ode.nonstiff;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
 
 /**
@@ -44,8 +46,9 @@ import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
 class EulerStepInterpolator
   extends RungeKuttaStepInterpolator {
 
-  /** Serializable version identifier. */
-  private static final long serialVersionUID = 20111120L;
+    /** Serializable version identifier. */
+    @Serial
+    private static final long serialVersionUID = 20111120L;
 
   /** Simple constructor.
    * This constructor builds an instance that is not usable yet, the

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/GillStepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/GillStepInterpolator.java
@@ -18,7 +18,10 @@
 package org.apache.commons.math4.legacy.ode.nonstiff;
 
 import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
+
 import org.apache.commons.math4.core.jdkmath.JdkMath;
+
+import java.io.Serial;
 
 /**
  * This class implements a step interpolator for the Gill fourth
@@ -61,6 +64,7 @@ class GillStepInterpolator
     private static final double ONE_PLUS_INV_SQRT_2 = 1 + JdkMath.sqrt(0.5);
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 20111120L;
 
   /** Simple constructor.

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/GraggBulirschStoerStepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/GraggBulirschStoerStepInterpolator.java
@@ -20,6 +20,7 @@ package org.apache.commons.math4.legacy.ode.nonstiff;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serial;
 
 import org.apache.commons.math4.legacy.ode.EquationsMapper;
 import org.apache.commons.math4.legacy.ode.sampling.AbstractStepInterpolator;
@@ -78,6 +79,7 @@ class GraggBulirschStoerStepInterpolator
   extends AbstractStepInterpolator {
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 20110928L;
 
     /** Slope at the beginning of the step. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/HighamHall54StepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/HighamHall54StepInterpolator.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.math4.legacy.ode.nonstiff;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
 
 /**
@@ -31,8 +33,9 @@ import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
 class HighamHall54StepInterpolator
   extends RungeKuttaStepInterpolator {
 
-  /** Serializable version identifier. */
-  private static final long serialVersionUID = 20111120L;
+    /** Serializable version identifier. */
+    @Serial
+    private static final long serialVersionUID = 20111120L;
 
   /** Simple constructor.
    * This constructor builds an instance that is not usable yet, the

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/LutherStepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/LutherStepInterpolator.java
@@ -18,7 +18,10 @@
 package org.apache.commons.math4.legacy.ode.nonstiff;
 
 import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
+
 import org.apache.commons.math4.core.jdkmath.JdkMath;
+
+import java.io.Serial;
 
 /**
  * This class represents an interpolator over the last step during an
@@ -35,6 +38,7 @@ import org.apache.commons.math4.core.jdkmath.JdkMath;
 class LutherStepInterpolator extends RungeKuttaStepInterpolator {
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 20140416L;
 
     /** Square root. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/MidpointStepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/MidpointStepInterpolator.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.math4.legacy.ode.nonstiff;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
 
 /**
@@ -46,8 +48,9 @@ import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
 class MidpointStepInterpolator
   extends RungeKuttaStepInterpolator {
 
-  /** Serializable version identifier. */
-  private static final long serialVersionUID = 20111120L;
+    /** Serializable version identifier. */
+    @Serial
+    private static final long serialVersionUID = 20111120L;
 
   /** Simple constructor.
    * This constructor builds an instance that is not usable yet, the

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/ThreeEighthesStepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/nonstiff/ThreeEighthesStepInterpolator.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.math4.legacy.ode.nonstiff;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
 
 /**
@@ -56,8 +58,9 @@ import org.apache.commons.math4.legacy.ode.sampling.StepInterpolator;
 class ThreeEighthesStepInterpolator
   extends RungeKuttaStepInterpolator {
 
-  /** Serializable version identifier. */
-  private static final long serialVersionUID = 20111120L;
+    /** Serializable version identifier. */
+    @Serial
+    private static final long serialVersionUID = 20111120L;
 
   /** Simple constructor.
    * This constructor builds an instance that is not usable yet, the

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/sampling/NordsieckStepInterpolator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/ode/sampling/NordsieckStepInterpolator.java
@@ -20,6 +20,7 @@ package org.apache.commons.math4.legacy.ode.sampling;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serial;
 import java.util.Arrays;
 
 import org.apache.commons.math4.legacy.exception.MaxCountExceededException;
@@ -41,6 +42,7 @@ import org.apache.commons.math4.core.jdkmath.JdkMath;
 public class NordsieckStepInterpolator extends AbstractStepInterpolator {
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -7179861704951334960L;
 
     /** State variation. */

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/BaseMultivariateOptimizer.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/BaseMultivariateOptimizer.java
@@ -83,12 +83,11 @@ public abstract class BaseMultivariateOptimizer<PAIR>
         // The existing values (as set by the previous call) are reused if
         // not provided in the argument list.
         for (OptimizationData data : optData) {
-            if (data instanceof InitialGuess) {
-                start = ((InitialGuess) data).getInitialGuess();
+            if (data instanceof InitialGuess guess) {
+                start = guess.getInitialGuess();
                 continue;
             }
-            if (data instanceof SimpleBounds) {
-                final SimpleBounds bounds = (SimpleBounds) data;
+            if (data instanceof SimpleBounds bounds) {
                 lowerBound = bounds.getLower();
                 upperBound = bounds.getUpper();
                 continue;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/BaseOptimizer.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/BaseOptimizer.java
@@ -235,20 +235,19 @@ public abstract class BaseOptimizer<PAIR> {
         // The existing values (as set by the previous call) are reused if
         // not provided in the argument list.
         for (OptimizationData data : optData) {
-            if (data instanceof MaxEval) {
-                maxEvaluations = ((MaxEval) data).getMaxEval();
+            if (data instanceof MaxEval eval) {
+                maxEvaluations = eval.getMaxEval();
                 continue;
             }
-            if (data instanceof MaxIter) {
-                maxIterations = ((MaxIter) data).getMaxIter();
+            if (data instanceof MaxIter iter) {
+                maxIterations = iter.getMaxIter();
                 continue;
             }
             if (data instanceof ConvergenceChecker) {
                 checker = (ConvergenceChecker<PAIR>) data;
                 continue;
             }
-            if (data instanceof Tolerance) {
-               final Tolerance tol = (Tolerance) data;
+            if (data instanceof Tolerance tol) {
                relativeTolerance = tol.getRelativeTolerance();
                absoluteTolerance = tol.getAbsoluteTolerance();
                continue;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/PointValuePair.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/PointValuePair.java
@@ -79,8 +79,7 @@ public final class PointValuePair extends Pair<double[], Double> {
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof PointValuePair) {
-            final PointValuePair other = (PointValuePair) o;
+        if (o instanceof PointValuePair other) {
 
             return getValue().equals(other.getValue()) &&
                 Arrays.equals(getPointRef(),

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/LinearConstraint.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/LinearConstraint.java
@@ -180,8 +180,7 @@ public class LinearConstraint {
         if (this == other) {
             return true;
         }
-        if (other instanceof LinearConstraint) {
-            LinearConstraint rhs = (LinearConstraint) other;
+        if (other instanceof LinearConstraint rhs) {
             return relationship == rhs.relationship &&
                 value == rhs.value &&
                 coefficients.equals(rhs.coefficients);

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/LinearObjectiveFunction.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/LinearObjectiveFunction.java
@@ -103,8 +103,7 @@ public class LinearObjectiveFunction
         if (this == other) {
             return true;
         }
-        if (other instanceof LinearObjectiveFunction) {
-            LinearObjectiveFunction rhs = (LinearObjectiveFunction) other;
+        if (other instanceof LinearObjectiveFunction rhs) {
           return constantTerm == rhs.constantTerm && coefficients.equals(rhs.coefficients);
         }
 

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/LinearOptimizer.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/LinearOptimizer.java
@@ -115,16 +115,16 @@ public abstract class LinearOptimizer
         // The existing values (as set by the previous call) are reused if
         // not provided in the argument list.
         for (OptimizationData data : optData) {
-            if (data instanceof LinearObjectiveFunction) {
-                function = (LinearObjectiveFunction) data;
+            if (data instanceof LinearObjectiveFunction objectiveFunction) {
+                function = objectiveFunction;
                 continue;
             }
-            if (data instanceof LinearConstraintSet) {
-                linearConstraints = ((LinearConstraintSet) data).getConstraints();
+            if (data instanceof LinearConstraintSet set) {
+                linearConstraints = set.getConstraints();
                 continue;
             }
-            if  (data instanceof NonNegativeConstraint) {
-                nonNegative = ((NonNegativeConstraint) data).isRestrictedToNonNegative();
+            if  (data instanceof NonNegativeConstraint constraint) {
+                nonNegative = constraint.isRestrictedToNonNegative();
                 continue;
             }
         }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/NoFeasibleSolutionException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/NoFeasibleSolutionException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.optim.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalStateException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class NoFeasibleSolutionException extends MathIllegalStateException {
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = -3044253632189082760L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/SimplexSolver.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/SimplexSolver.java
@@ -177,12 +177,12 @@ public class SimplexSolver extends LinearOptimizer {
         solutionCallback = null;
 
         for (OptimizationData data : optData) {
-            if (data instanceof SolutionCallback) {
-                solutionCallback = (SolutionCallback) data;
+            if (data instanceof SolutionCallback callback) {
+                solutionCallback = callback;
                 continue;
             }
-            if (data instanceof PivotSelectionRule) {
-                pivotSelection = (PivotSelectionRule) data;
+            if (data instanceof PivotSelectionRule rule) {
+                pivotSelection = rule;
                 continue;
             }
         }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/SimplexTableau.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/SimplexTableau.java
@@ -852,8 +852,7 @@ class SimplexTableau {
         return true;
       }
 
-      if (other instanceof SimplexTableau) {
-          SimplexTableau rhs = (SimplexTableau) other;
+      if (other instanceof SimplexTableau rhs) {
           return restrictToNonNegative  == rhs.restrictToNonNegative &&
                  numDecisionVariables   == rhs.numDecisionVariables &&
                  numSlackVariables      == rhs.numSlackVariables &&

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/UnboundedSolutionException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/linear/UnboundedSolutionException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.optim.linear;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalStateException;
 import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.LocalizedFormats;
  */
 public class UnboundedSolutionException extends MathIllegalStateException {
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 940539497277290619L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/GradientMultivariateOptimizer.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/GradientMultivariateOptimizer.java
@@ -91,8 +91,8 @@ public abstract class GradientMultivariateOptimizer
         // The existing values (as set by the previous call) are reused if
         // not provided in the argument list.
         for (OptimizationData data : optData) {
-            if  (data instanceof ObjectiveFunctionGradient) {
-                gradient = ((ObjectiveFunctionGradient) data).getObjectiveFunctionGradient();
+            if  (data instanceof ObjectiveFunctionGradient functionGradient) {
+                gradient = functionGradient.getObjectiveFunctionGradient();
                 // If more data must be parsed, this statement _must_ be
                 // changed to "continue".
                 break;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/MultivariateOptimizer.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/MultivariateOptimizer.java
@@ -99,12 +99,12 @@ public abstract class MultivariateOptimizer
         // The existing values (as set by the previous call) are reused if
         // not provided in the argument list.
         for (OptimizationData data : optData) {
-            if (data instanceof GoalType) {
-                goal = (GoalType) data;
+            if (data instanceof GoalType type) {
+                goal = type;
                 continue;
             }
-            if (data instanceof ObjectiveFunction) {
-                final MultivariateFunction delegate = ((ObjectiveFunction) data).getObjectiveFunction();
+            if (data instanceof ObjectiveFunction objectiveFunction) {
+                final MultivariateFunction delegate = objectiveFunction.getObjectiveFunction();
                 function = new MultivariateFunction() {
                         @Override
                         public double value(double[] point) {
@@ -114,8 +114,7 @@ public abstract class MultivariateOptimizer
                     };
                 continue;
             }
-            if (data instanceof LineSearchTolerance) {
-                final LineSearchTolerance tol = (LineSearchTolerance) data;
+            if (data instanceof LineSearchTolerance tol) {
                 lineSearchRelativeTolerance = tol.getRelativeTolerance();
                 lineSearchAbsoluteTolerance = tol.getAbsoluteTolerance();
                 lineSearchInitialBracketingRange = tol.getInitialBracketingRange();

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/noderiv/CMAESOptimizer.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/noderiv/CMAESOptimizer.java
@@ -482,12 +482,12 @@ public class CMAESOptimizer
         // The existing values (as set by the previous call) are reused if
         // not provided in the argument list.
         for (OptimizationData data : optData) {
-            if (data instanceof Sigma) {
-                inputSigma = ((Sigma) data).getSigma();
+            if (data instanceof Sigma sigma1) {
+                inputSigma = sigma1.getSigma();
                 continue;
             }
-            if (data instanceof PopulationSize) {
-                lambda = ((PopulationSize) data).getPopulationSize();
+            if (data instanceof PopulationSize size) {
+                lambda = size.getPopulationSize();
                 continue;
             }
         }
@@ -830,8 +830,8 @@ public class CMAESOptimizer
                 return true;
             }
 
-            if (other instanceof DoubleIndex) {
-                return Double.compare(value, ((DoubleIndex) other).value) == 0;
+            if (other instanceof DoubleIndex doubleIndex) {
+                return Double.compare(value, doubleIndex.value) == 0;
             }
 
             return false;

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/noderiv/SimplexOptimizer.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/noderiv/SimplexOptimizer.java
@@ -303,14 +303,14 @@ public class SimplexOptimizer extends MultivariateOptimizer {
         // The existing values (as set by the previous call) are reused
         // if not provided in the argument list.
         for (OptimizationData data : optData) {
-            if (data instanceof Simplex) {
-                initialSimplex = (Simplex) data;
-            } else if (data instanceof Simplex.TransformFactory) {
-                updateRule = (Simplex.TransformFactory) data;
-            } else if (data instanceof SimulatedAnnealing) {
-                simulatedAnnealing = (SimulatedAnnealing) data;
-            } else if (data instanceof PopulationSize) {
-                populationSize = ((PopulationSize) data).getPopulationSize();
+            if (data instanceof Simplex simplex) {
+                initialSimplex = simplex;
+            } else if (data instanceof Simplex.TransformFactory factory) {
+                updateRule = factory;
+            } else if (data instanceof SimulatedAnnealing annealing) {
+                simulatedAnnealing = annealing;
+            } else if (data instanceof PopulationSize size) {
+                populationSize = size.getPopulationSize();
             }
         }
     }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/univariate/UnivariateOptimizer.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/optim/univariate/UnivariateOptimizer.java
@@ -97,15 +97,14 @@ public abstract class UnivariateOptimizer
         // The existing values (as set by the previous call) are reused if
         // not provided in the argument list.
         for (OptimizationData data : optData) {
-            if (data instanceof SearchInterval) {
-                final SearchInterval interval = (SearchInterval) data;
+            if (data instanceof SearchInterval interval) {
                 min = interval.getMin();
                 max = interval.getMax();
                 start = interval.getStartValue();
                 continue;
             }
-            if (data instanceof UnivariateObjectiveFunction) {
-                final UnivariateFunction delegate = ((UnivariateObjectiveFunction) data).getObjectiveFunction();
+            if (data instanceof UnivariateObjectiveFunction objectiveFunction) {
+                final UnivariateFunction delegate = objectiveFunction.getObjectiveFunction();
                 function = new UnivariateFunction() {
                         @Override
                         public double value(double point) {
@@ -115,8 +114,8 @@ public abstract class UnivariateOptimizer
                     };
                 continue;
             }
-            if (data instanceof GoalType) {
-                goal = (GoalType) data;
+            if (data instanceof GoalType type) {
+                goal = type;
                 continue;
             }
         }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/correlation/SpearmansCorrelation.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/correlation/SpearmansCorrelation.java
@@ -66,8 +66,8 @@ public class SpearmansCorrelation {
     public SpearmansCorrelation(final RankingAlgorithm rankingAlgorithm)
         throws MathIllegalArgumentException {
 
-        if (rankingAlgorithm instanceof NaturalRanking &&
-            NaNStrategy.REMOVED == ((NaturalRanking) rankingAlgorithm).getNanStrategy()) {
+        if (rankingAlgorithm instanceof NaturalRanking ranking &&
+            NaNStrategy.REMOVED == ranking.getNanStrategy()) {
             throw new MathIllegalArgumentException(LocalizedFormats.NOT_SUPPORTED_NAN_STRATEGY,
                                                    NaNStrategy.REMOVED);
         }
@@ -100,8 +100,8 @@ public class SpearmansCorrelation {
     public SpearmansCorrelation(final RealMatrix dataMatrix, final RankingAlgorithm rankingAlgorithm)
         throws MathIllegalArgumentException {
 
-        if (rankingAlgorithm instanceof NaturalRanking &&
-            NaNStrategy.REMOVED == ((NaturalRanking) rankingAlgorithm).getNanStrategy()) {
+        if (rankingAlgorithm instanceof NaturalRanking ranking &&
+            NaNStrategy.REMOVED == ranking.getNanStrategy()) {
             throw new MathIllegalArgumentException(LocalizedFormats.NOT_SUPPORTED_NAN_STRATEGY,
                                                    NaNStrategy.REMOVED);
         }

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/descriptive/DescriptiveStatistics.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/descriptive/DescriptiveStatistics.java
@@ -445,8 +445,8 @@ public class DescriptiveStatistics implements StatisticalSummary {
      * @throws MathIllegalArgumentException if p is not a valid quantile
      */
     public double getPercentile(double p) throws MathIllegalStateException, MathIllegalArgumentException {
-        if (percentileImpl instanceof Percentile) {
-            ((Percentile) percentileImpl).setQuantile(p);
+        if (percentileImpl instanceof Percentile percentile) {
+            percentile.setQuantile(p);
         } else {
             try {
                 percentileImpl.getClass().getMethod(SET_QUANTILE_METHOD_NAME, Double.TYPE)

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/descriptive/rank/PSquarePercentile.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/descriptive/rank/PSquarePercentile.java
@@ -165,12 +165,12 @@ public class PSquarePercentile extends AbstractStorelessUnivariateStatistic
     public String toString() {
 
         if (markers == null) {
-            return String.format("obs=%s pValue=%s",
-                    DECIMAL_FORMAT.format(lastObservation),
-                    DECIMAL_FORMAT.format(pValue));
+            return "obs=%s pValue=%s".formatted(
+                DECIMAL_FORMAT.format(lastObservation),
+                DECIMAL_FORMAT.format(pValue));
         } else {
-            return String.format("obs=%s markers=%s",
-                    DECIMAL_FORMAT.format(lastObservation), markers.toString());
+            return "obs=%s markers=%s".formatted(
+                DECIMAL_FORMAT.format(lastObservation), markers.toString());
         }
     }
 
@@ -483,10 +483,10 @@ public class PSquarePercentile extends AbstractStorelessUnivariateStatistic
          */
         @Override
         public String toString() {
-            return String.format("m1=[%s],m2=[%s],m3=[%s],m4=[%s],m5=[%s]",
-                    markerArray[1].toString(), markerArray[2].toString(),
-                    markerArray[3].toString(), markerArray[4].toString(),
-                    markerArray[5].toString());
+            return "m1=[%s],m2=[%s],m3=[%s],m4=[%s],m5=[%s]".formatted(
+                markerArray[1].toString(), markerArray[2].toString(),
+                markerArray[3].toString(), markerArray[4].toString(),
+                markerArray[5].toString());
         }
     }
 
@@ -699,13 +699,12 @@ public class PSquarePercentile extends AbstractStorelessUnivariateStatistic
          */
         @Override
         public String toString() {
-            return String.format(
-                    "index=%.0f,n=%.0f,np=%.2f,q=%.2f,dn=%.2f,prev=%d,next=%d",
-                    (double) index, Precision.round(intMarkerPosition, 0),
-                    Precision.round(desiredMarkerPosition, 2),
-                    Precision.round(markerHeight, 2),
-                    Precision.round(desiredMarkerIncrement, 2), previous.index,
-                    next.index);
+            return "index=%.0f,n=%.0f,np=%.2f,q=%.2f,dn=%.2f,prev=%d,next=%d".formatted(
+                (double) index, Precision.round(intMarkerPosition, 0),
+                Precision.round(desiredMarkerPosition, 2),
+                Precision.round(markerHeight, 2),
+                Precision.round(desiredMarkerIncrement, 2), previous.index,
+                next.index);
         }
     }
 

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/regression/ModelSpecificationException.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/stat/regression/ModelSpecificationException.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.math4.legacy.stat.regression;
 
+import java.io.Serial;
+
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
 import org.apache.commons.math4.legacy.exception.util.Localizable;
 
@@ -26,6 +28,7 @@ import org.apache.commons.math4.legacy.exception.util.Localizable;
  */
 public class ModelSpecificationException extends MathIllegalArgumentException {
     /** Serializable version Id. */
+    @Serial
     private static final long serialVersionUID = 4206514456095401070L;
 
     /**

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/util/ComplexFormat.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/util/ComplexFormat.java
@@ -268,10 +268,10 @@ public class ComplexFormat {
 
         StringBuffer ret = null;
 
-        if (obj instanceof Complex) {
-            ret = format( (Complex)obj, toAppendTo, pos);
-        } else if (obj instanceof Number) {
-            ret = format(Complex.ofCartesian(((Number)obj).doubleValue(), 0.0),
+        if (obj instanceof Complex complex) {
+            ret = format( complex, toAppendTo, pos);
+        } else if (obj instanceof Number number) {
+            ret = format(Complex.ofCartesian(number.doubleValue(), 0.0),
                          toAppendTo, pos);
         } else {
             throw new MathIllegalArgumentException(LocalizedFormats.CANNOT_FORMAT_INSTANCE_AS_COMPLEX,

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/field/linalg/FP64FieldDenseMatrixTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/field/linalg/FP64FieldDenseMatrixTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.math4.legacy.field.linalg;
 
+import java.util.concurrent.ThreadLocalRandom;
+
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.apache.commons.numbers.field.FP64;
@@ -274,7 +277,7 @@ public class FP64FieldDenseMatrixTest {
         final RealMatrix b = new Array2DRowRealMatrix(r, c);
         for (int i = 0; i < r; i++) {
             for (int j = 0; j < c; j++) {
-                final double v = scale * (2 * Math.random() - 1);
+                final double v = scale * (2 * ThreadLocalRandom.current().nextDouble() - 1);
                 a.set(i, j, FP64.of(v));
                 b.setEntry(i, j, v);
             }

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/ArrayFieldVectorTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/ArrayFieldVectorTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.math4.legacy.linear;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.apache.commons.math4.legacy.core.Field;
 import org.apache.commons.math4.legacy.core.FieldElement;
@@ -615,7 +616,7 @@ public class ArrayFieldVectorTest {
         final int n = 2;
         ArrayFieldVector<BigReal> v = new ArrayFieldVector<>(BigRealField.getInstance());
         for (int i = 0; i < n; i++) {
-            v.append(new BigReal(Math.random()));
+            v.append(new BigReal(ThreadLocalRandom.current().nextDouble()));
         }
         Assert.assertEquals(v, TestUtils.serializeAndRecover(v));
     }

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/ConjugateGradientTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/ConjugateGradientTest.java
@@ -90,7 +90,7 @@ public class ConjugateGradientTest {
                 final double actual = x.getEntry(i);
                 final double expected = ainv.getEntry(i, j);
                 final double delta = 1E-10 * JdkMath.abs(expected);
-                final String msg = String.format("entry[%d][%d]", i, j);
+                final String msg = "entry[%d][%d]".formatted(i, j);
                 Assert.assertEquals(msg, expected, actual, delta);
             }
         }
@@ -116,7 +116,7 @@ public class ConjugateGradientTest {
                 final double actual = x.getEntry(i);
                 final double expected = ainv.getEntry(i, j);
                 final double delta = 1E-10 * JdkMath.abs(expected);
-                final String msg = String.format("entry[%d][%d)", i, j);
+                final String msg = "entry[%d][%d)".formatted(i, j);
                 Assert.assertEquals(msg, expected, actual, delta);
             }
         }
@@ -142,7 +142,7 @@ public class ConjugateGradientTest {
                 final double actual = x.getEntry(i);
                 final double expected = ainv.getEntry(i, j);
                 final double delta = 1E-10 * JdkMath.abs(expected);
-                final String msg = String.format("entry[%d][%d]", i, j);
+                final String msg = "entry[%d][%d]".formatted(i, j);
                 Assert.assertEquals(msg, expected, actual, delta);
                 Assert.assertEquals(msg, x0.getEntry(i), 1., Math.ulp(1.));
             }
@@ -207,8 +207,8 @@ public class ConjugateGradientTest {
                     final double actual = b.getEntry(i) - y.getEntry(i);
                     final double expected = r.getEntry(i);
                     final double delta = 1E-6 * JdkMath.abs(expected);
-                    final String msg = String
-                        .format("column %d, residual %d", i, j);
+                    final String msg = "column %d, residual %d"
+                        .formatted(i, j);
                     Assert.assertEquals(msg, expected, actual, delta);
                 }
             }
@@ -323,7 +323,7 @@ public class ConjugateGradientTest {
                 final double actual = x.getEntry(i);
                 final double expected = ainv.getEntry(i, j);
                 final double delta = 1E-6 * JdkMath.abs(expected);
-                final String msg = String.format("coefficient (%d, %d)", i, j);
+                final String msg = "coefficient (%d, %d)".formatted(i, j);
                 Assert.assertEquals(msg, expected, actual, delta);
             }
         }
@@ -383,7 +383,7 @@ public class ConjugateGradientTest {
                     final double actual = b.getEntry(i) - y.getEntry(i);
                     final double expected = r.getEntry(i);
                     final double delta = 1E-6 * JdkMath.abs(expected);
-                    final String msg = String.format("column %d, residual %d", i, j);
+                    final String msg = "column %d, residual %d".formatted(i, j);
                     Assert.assertEquals(msg, expected, actual, delta);
                 }
             }
@@ -424,10 +424,10 @@ public class ConjugateGradientTest {
             final RealVector x = cg.solve(a, b);
             final int npcg = pcg.getIterationManager().getIterations();
             final int ncg = cg.getIterationManager().getIterations();
-            msg = String.format(pattern, npcg, ncg);
+            msg = pattern.formatted(npcg, ncg);
             Assert.assertTrue(msg, npcg < ncg);
             for (int i = 0; i < n; i++) {
-                msg = String.format("row %d, column %d", i, j);
+                msg = "row %d, column %d".formatted(i, j);
                 final double expected = x.getEntry(i);
                 final double actual = px.getEntry(i);
                 final double delta = 1E-6 * JdkMath.abs(expected);
@@ -509,9 +509,9 @@ public class ConjugateGradientTest {
             b.set(0.);
             b.setEntry(j, 1.);
             solver.solve(a, b);
-            String msg = String.format("column %d (initialization)", j);
+            String msg = "column %d (initialization)".formatted(j);
             Assert.assertEquals(msg, 1, count[0]);
-            msg = String.format("column %d (finalization)", j);
+            msg = "column %d (finalization)".formatted(j);
             Assert.assertEquals(msg, 1, count[3]);
         }
     }

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/SymmLQTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/SymmLQTest.java
@@ -256,7 +256,7 @@ public class SymmLQTest {
                 final double actual = x.getEntry(i);
                 final double expected = ainv.getEntry(i, j);
                 final double delta = 1E-6 * JdkMath.abs(expected);
-                final String msg = String.format("entry[%d][%d]", i, j);
+                final String msg = "entry[%d][%d]".formatted(i, j);
                 Assert.assertEquals(msg, expected, actual, delta);
             }
         }
@@ -282,7 +282,7 @@ public class SymmLQTest {
                 final double actual = x.getEntry(i);
                 final double expected = ainv.getEntry(i, j);
                 final double delta = 1E-6 * JdkMath.abs(expected);
-                final String msg = String.format("entry[%d][%d)", i, j);
+                final String msg = "entry[%d][%d)".formatted(i, j);
                 Assert.assertEquals(msg, expected, actual, delta);
             }
         }
@@ -308,7 +308,7 @@ public class SymmLQTest {
                 final double actual = x.getEntry(i);
                 final double expected = ainv.getEntry(i, j);
                 final double delta = 1E-6 * JdkMath.abs(expected);
-                final String msg = String.format("entry[%d][%d]", i, j);
+                final String msg = "entry[%d][%d]".formatted(i, j);
                 Assert.assertEquals(msg, expected, actual, delta);
                 Assert.assertEquals(msg, x0.getEntry(i), 1., Math.ulp(1.));
             }
@@ -420,7 +420,7 @@ public class SymmLQTest {
                 final double actual = x.getEntry(i);
                 final double expected = ainv.getEntry(i, j);
                 final double delta = 1E-6 * JdkMath.abs(expected);
-                final String msg = String.format("coefficient (%d, %d)", i, j);
+                final String msg = "coefficient (%d, %d)".formatted(i, j);
                 Assert.assertEquals(msg, expected, actual, delta);
             }
         }
@@ -459,9 +459,9 @@ public class SymmLQTest {
             final RealVector x = unprec.solve(a, b);
             final int np = prec.getIterationManager().getIterations();
             final int nup = unprec.getIterationManager().getIterations();
-            msg = String.format(pattern, np, nup);
+            msg = pattern.formatted(np, nup);
             for (int i = 0; i < n; i++) {
-                msg = String.format("row %d, column %d", i, j);
+                msg = "row %d, column %d".formatted(i, j);
                 final double expected = x.getEntry(i);
                 final double actual = px.getEntry(i);
                 final double delta = 5E-5 * JdkMath.abs(expected);
@@ -523,9 +523,9 @@ public class SymmLQTest {
             b.set(0.);
             b.setEntry(j, 1.);
             final RealVector xFromSolver = solver.solve(a, b);
-            String msg = String.format("column %d (initialization)", j);
+            String msg = "column %d (initialization)".formatted(j);
             Assert.assertEquals(msg, 1, count[0]);
-            msg = String.format("column %d (finalization)", j);
+            msg = "column %d (finalization)".formatted(j);
             Assert.assertEquals(msg, 1, count[3]);
             /*
              *  Check that solution is not "over-refined". When the last
@@ -533,7 +533,7 @@ public class SymmLQTest {
              *  performed.
              */
             for (int i = 0; i < n; i++){
-                msg = String.format("row %d, column %d", i, j);
+                msg = "row %d, column %d".formatted(i, j);
                 final double expected = xFromSolver.getEntry(i);
                 final double actual = xFromListener.getEntry(i);
                 Assert.assertEquals(msg, expected, actual, 0.0);

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/UnmodifiableRealVectorAbstractTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/UnmodifiableRealVectorAbstractTest.java
@@ -195,45 +195,45 @@ public abstract class UnmodifiableRealVectorAbstractTest {
      */
     public static boolean equals(final Object x, final Object y) {
         if (x instanceof Boolean) {
-            if (y instanceof Boolean) {
-                return ((Boolean) x).booleanValue() == ((Boolean) y)
+            if (y instanceof Boolean boolean1) {
+                return ((Boolean) x).booleanValue() == boolean1
                         .booleanValue();
             } else {
                 return false;
             }
         }
         if (x instanceof Integer) {
-            if (y instanceof Integer) {
-                return ((Integer) x).intValue() == ((Integer) y).intValue();
+            if (y instanceof Integer integer) {
+                return ((Integer) x).intValue() == integer.intValue();
             } else {
                 return false;
             }
         } else if (x instanceof Double) {
-            if (y instanceof Double) {
+            if (y instanceof Double double1) {
                 return equals(((Double) x).doubleValue(),
-                        ((Double) y).doubleValue());
+                        double1.doubleValue());
             } else {
                 return false;
             }
         } else if (x instanceof double[]) {
-            if (y instanceof double[]) {
-                return equals((double[]) x, (double[]) y);
-            } else if (y instanceof RealVector) {
-                return equals((RealVector) y, (double[]) x);
+            if (y instanceof double[] doubles) {
+                return equals((double[]) x, doubles);
+            } else if (y instanceof RealVector vector) {
+                return equals(vector, (double[]) x);
             } else {
                 return false;
             }
         } else if (x instanceof RealVector) {
-            if (y instanceof double[]) {
-                return equals((RealVector) x, (double[]) y);
-            } else if (y instanceof RealVector) {
-                return equals((RealVector) x, (RealVector) y);
+            if (y instanceof double[] doubles1) {
+                return equals((RealVector) x, doubles1);
+            } else if (y instanceof RealVector vector1) {
+                return equals((RealVector) x, vector1);
             } else {
                 return false;
             }
         } else if (x instanceof RealMatrix) {
-            if (y instanceof RealMatrix) {
-                return equals((RealMatrix) x, (RealMatrix) y);
+            if (y instanceof RealMatrix matrix) {
+                return equals((RealMatrix) x, matrix);
             } else {
                 return false;
             }

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/ml/clustering/MiniBatchKMeansClustererTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/ml/clustering/MiniBatchKMeansClustererTest.java
@@ -84,7 +84,7 @@ public class MiniBatchKMeansClustererTest {
             double scoreDiffRatio = (kMeansScore - miniBatchKMeansScore) /
                     kMeansScore;
             // MiniBatchKMeansClusterer has few score differences between KMeansClusterer(less then 10%).
-            Assert.assertTrue(String.format("Different score ratio %f%%!, diff points ratio: %f%%", scoreDiffRatio * 100, diffPointsRatio * 100),
+            Assert.assertTrue("Different score ratio %f%%!, diff points ratio: %f%%".formatted(scoreDiffRatio * 100, diffPointsRatio * 100),
                     scoreDiffRatio < 0.1);
         }
     }
@@ -135,7 +135,7 @@ public class MiniBatchKMeansClustererTest {
     public static void assertException(Runnable block, Class<? extends Throwable> exceptionClass) {
         try {
             block.run();
-            Assert.fail(String.format("Expects %s", exceptionClass.getSimpleName()));
+            Assert.fail("Expects %s".formatted(exceptionClass.getSimpleName()));
         } catch (Throwable e) {
             if (!exceptionClass.isInstance(e)) {
                 throw e;

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/ode/nonstiff/Decimal64.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/ode/nonstiff/Decimal64.java
@@ -17,7 +17,10 @@
 package org.apache.commons.math4.legacy.ode.nonstiff;
 
 import org.apache.commons.numbers.core.Sum;
+
 import org.apache.commons.math4.core.jdkmath.JdkMath;
+
+import java.io.Serial;
 import org.apache.commons.math4.legacy.core.Field;
 import org.apache.commons.math4.legacy.core.RealFieldElement;
 import org.apache.commons.math4.legacy.exception.DimensionMismatchException;
@@ -54,6 +57,7 @@ public class Decimal64 extends Number
     public static final Decimal64 NAN;
 
     /** */
+    @Serial
     private static final long serialVersionUID = 20120227L;
 
     static {
@@ -254,8 +258,7 @@ public class Decimal64 extends Number
     /** {@inheritDoc} */
     @Override
     public boolean equals(final Object obj) {
-        if (obj instanceof Decimal64) {
-            final Decimal64 that = (Decimal64) obj;
+        if (obj instanceof Decimal64 that) {
             return Double.doubleToLongBits(this.value) == Double
                     .doubleToLongBits(that.value);
         }

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/ode/sampling/DummyStepInterpolator.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/ode/sampling/DummyStepInterpolator.java
@@ -20,6 +20,7 @@ package org.apache.commons.math4.legacy.ode.sampling;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.io.Serial;
 
 import org.apache.commons.math4.legacy.ode.EquationsMapper;
 
@@ -39,8 +40,9 @@ import org.apache.commons.math4.legacy.ode.EquationsMapper;
 public class DummyStepInterpolator
   extends AbstractStepInterpolator {
 
-  /** Serializable version identifier. */
-  private static final long serialVersionUID = 1708010296707839488L;
+    /** Serializable version identifier. */
+    @Serial
+    private static final long serialVersionUID = 1708010296707839488L;
 
   /** Current derivative. */
   private double[] currentDerivative;

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/noderiv/SimplexOptimizerTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/optim/nonlinear/scalar/noderiv/SimplexOptimizerTest.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.io.PrintWriter;
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -250,7 +250,7 @@ public class SimplexOptimizerTest {
                                                                factory + sep);
 
             // Create file; write first data block (optimum) and columns header.
-            try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(name)))) {
+            try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(Path.of(name)))) {
                 out.println("# Function: " + function);
                 out.println("# Transform: " + factory);
                 out.println("#");
@@ -276,7 +276,7 @@ public class SimplexOptimizerTest {
 
             // Return callback function.
             return (simplex, isInit, numEval) -> {
-                try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(name),
+                try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(Path.of(name),
                                                                                StandardOpenOption.APPEND))) {
                     if (isInit) {
                         // Blank line indicating the start of an optimization
@@ -317,7 +317,7 @@ public class SimplexOptimizerTest {
         public void checkAlongLine(int numPoints) {
             if (tracePrefix != null) {
                 final String name = tracePrefix + createPlotBasename(function, start, optimum);
-                try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(Paths.get(name)))) {
+                try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(Path.of(name)))) {
                     checkAlongLine(numPoints, out);
                 } catch (IOException e) {
                     Assertions.fail(e.getMessage());

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/CertifiedDataTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/CertifiedDataTest.java
@@ -99,8 +99,8 @@ public class CertifiedDataTest {
 
         DescriptiveStatistics d = null;
         SummaryStatistics s = null;
-        if (u instanceof DescriptiveStatistics) {
-            d = (DescriptiveStatistics) u;
+        if (u instanceof DescriptiveStatistics statistics) {
+            d = statistics;
         } else {
             s = (SummaryStatistics) u;
         }

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/descriptive/DescriptiveStatisticsTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/descriptive/DescriptiveStatisticsTest.java
@@ -149,15 +149,17 @@ public class DescriptiveStatisticsTest {
         stats.addValue(3);
         Locale d = Locale.getDefault();
         Locale.setDefault(Locale.US);
-        Assert.assertEquals("DescriptiveStatistics:\n" +
-                     "n: 3\n" +
-                     "min: 1.0\n" +
-                     "max: 3.0\n" +
-                     "mean: 2.0\n" +
-                     "std dev: 1.0\n" +
-                     "median: 2.0\n" +
-                     "skewness: 0.0\n" +
-                     "kurtosis: NaN\n",  stats.toString());
+        Assert.assertEquals("""
+                     DescriptiveStatistics:
+                     n: 3
+                     min: 1.0
+                     max: 3.0
+                     mean: 2.0
+                     std dev: 1.0
+                     median: 2.0
+                     skewness: 0.0
+                     kurtosis: NaN
+                     """,  stats.toString());
         Locale.setDefault(d);
     }
 

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/descriptive/StatisticalSummaryValuesTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/descriptive/StatisticalSummaryValuesTest.java
@@ -42,14 +42,16 @@ public final class StatisticalSummaryValuesTest {
         StatisticalSummaryValues u  = new StatisticalSummaryValues(4.5, 16, 10, 5, 4, 45);
         Locale d = Locale.getDefault();
         Locale.setDefault(Locale.US);
-        Assert.assertEquals("StatisticalSummaryValues:\n" +
-                     "n: 10\n" +
-                     "min: 4.0\n" +
-                     "max: 5.0\n" +
-                     "mean: 4.5\n" +
-                     "std dev: 4.0\n" +
-                     "variance: 16.0\n" +
-                     "sum: 45.0\n",  u.toString());
+        Assert.assertEquals("""
+                     StatisticalSummaryValues:
+                     n: 10
+                     min: 4.0
+                     max: 5.0
+                     mean: 4.5
+                     std dev: 4.0
+                     variance: 16.0
+                     sum: 45.0
+                     """,  u.toString());
         Locale.setDefault(d);
     }
 }

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/descriptive/rank/PSquarePercentileTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/descriptive/rank/PSquarePercentileTest.java
@@ -414,9 +414,8 @@ public class PSquarePercentileTest extends
             double max = JdkMath.max(a, b);
             double percentage = JdkMath.abs(a - b) / max;
             double deviation = delta;
-            Assert.assertTrue(String.format(
-                    "Deviated = %f and is beyond %f as a=%f,  b=%f",
-                    percentage, deviation, a, b), percentage < deviation);
+            Assert.assertTrue("Deviated = %f and is beyond %f as a=%f,  b=%f".formatted(
+                percentage, deviation, a, b), percentage < deviation);
         }
     }
 
@@ -570,7 +569,7 @@ public class PSquarePercentileTest extends
         // Well the values deviate in our calculation by 0.25 so its 4.25 vs
         // 4.44
         Assert.assertEquals(
-                String.format("Expected=%f, Actual=%f", expected, p2value),
+            "Expected=%f, Actual=%f".formatted(expected, p2value),
                 expected, p2value, 0.25);
     }
 

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/regression/GLSMultipleLinearRegressionTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/stat/regression/GLSMultipleLinearRegressionTest.java
@@ -294,7 +294,7 @@ public class GLSMultipleLinearRegressionTest extends MultipleLinearRegressionAbs
 
         // Verify that GLS is on average more efficient, lower variance
         Assertions.assertTrue(olsBetaStats.getMean() > 1.1 * glsBetaStats.getMean(), 
-            () -> String.format("OLS %s : GLS %s", olsBetaStats.getMean(), glsBetaStats.getMean()));
+            () -> "OLS %s : GLS %s".formatted(olsBetaStats.getMean(), glsBetaStats.getMean()));
         Assert.assertTrue(olsBetaStats.getStandardDeviation() > glsBetaStats.getStandardDeviation());
     }
 }

--- a/commons-math-neuralnet/src/main/java/org/apache/commons/math4/neuralnet/internal/NeuralNetException.java
+++ b/commons-math-neuralnet/src/main/java/org/apache/commons/math4/neuralnet/internal/NeuralNetException.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.neuralnet.internal;
 
+import java.io.Serial;
 import java.text.MessageFormat;
 
 /**
@@ -40,6 +41,7 @@ public class NeuralNetException extends IllegalArgumentException {
     public static final String ID_NOT_FOUND = "Identifier not found: {0}";
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 20210515L;
 
     /**

--- a/commons-math-transform/src/main/java/org/apache/commons/math4/transform/TransformException.java
+++ b/commons-math-transform/src/main/java/org/apache/commons/math4/transform/TransformException.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.math4.transform;
 
+import java.io.Serial;
 import java.text.MessageFormat;
 
 /**
@@ -37,6 +38,7 @@ class TransformException extends IllegalArgumentException {
     public static final String NOT_POWER_OF_TWO = "{0} is not equal to pow(2, n), for some n";
 
     /** Serializable version identifier. */
+    @Serial
     private static final long serialVersionUID = 20210522L;
 
     /**

--- a/commons-math-transform/src/test/java/org/apache/commons/math4/transform/FastFourierTransformerTest.java
+++ b/commons-math-transform/src/test/java/org/apache/commons/math4/transform/FastFourierTransformerTest.java
@@ -185,10 +185,10 @@ public final class FastFourierTransformerTest {
             final int index = i;
             final double re = s * expected[i].getReal();
             assertEqualsRelativeOrAbsolute(re, actual[i].getReal(), tol, absTol,
-                () -> String.format("%s, %s, %d, %d", normalization, inverse, n, index));
+                () -> "%s, %s, %d, %d".formatted(normalization, inverse, n, index));
             final double im = s * expected[i].getImaginary();
             assertEqualsRelativeOrAbsolute(im, actual[i].getImaginary(), tol, absTol,
-                () -> String.format("%s, %s, %d, %d", normalization, inverse, n, index));
+                () -> "%s, %s, %d, %d".formatted(normalization, inverse, n, index));
         }
     }
 
@@ -225,10 +225,10 @@ public final class FastFourierTransformerTest {
             final int index = i;
             final double re = s * expected[i].getReal();
             assertEqualsRelativeOrAbsolute(re, actual[i].getReal(), tol, absTol,
-                () -> String.format("%s, %s, %d, %d", normalization, inverse, n, index));
+                () -> "%s, %s, %d, %d".formatted(normalization, inverse, n, index));
             final double im = s * expected[i].getImaginary();
             assertEqualsRelativeOrAbsolute(im, actual[i].getImaginary(), tol, absTol,
-                () -> String.format("%s, %s, %d, %d", normalization, inverse, n, index));
+                () -> "%s, %s, %d, %d".formatted(normalization, inverse, n, index));
         }
     }
 
@@ -268,10 +268,10 @@ public final class FastFourierTransformerTest {
             final int index = i;
             final double re = s * expected[i].getReal();
             assertEqualsRelativeOrAbsolute(re, actual[i].getReal(), tol, absTol,
-                () -> String.format("%s, %s, %d, %d", normalization, inverse, n, index));
+                () -> "%s, %s, %d, %d".formatted(normalization, inverse, n, index));
             final double im = s * expected[i].getImaginary();
             assertEqualsRelativeOrAbsolute(im, actual[i].getImaginary(), tol, absTol,
-                () -> String.format("%s, %s, %d, %d", normalization, inverse, n, index));
+                () -> "%s, %s, %d, %d".formatted(normalization, inverse, n, index));
         }
     }
 
@@ -283,7 +283,7 @@ public final class FastFourierTransformerTest {
             final double absoluteMax = Math.max(Math.abs(expected), Math.abs(actual));
             final double abs = Math.abs(expected - actual);
             final double rel = abs / absoluteMax;
-            final Supplier<String> message = () -> String.format("%s: rel=%s, abs=%s", msg.get(), rel, abs);
+            final Supplier<String> message = () -> "%s: rel=%s, abs=%s".formatted(msg.get(), rel, abs);
             // Re-use assertEquals to obtain the formatting
             Assertions.assertEquals(expected, actual, message);
         }

--- a/commons-math-transform/src/test/java/org/apache/commons/math4/transform/RealTransformerAbstractTest.java
+++ b/commons-math-transform/src/test/java/org/apache/commons/math4/transform/RealTransformerAbstractTest.java
@@ -300,7 +300,7 @@ public abstract class RealTransformerAbstractTest {
         final double[] actual = transformer.apply(x);
         for (int i = 0; i < n; i++) {
             final double delta = tol * Math.abs(expected[i]);
-            final String msg = String.format("%d, %d (%g, %g)", n, i, tol, delta);
+            final String msg = "%d, %d (%g, %g)".formatted(n, i, tol, delta);
             Assert.assertEquals(msg, expected[i], actual[i], delta);
         }
     }
@@ -320,7 +320,7 @@ public abstract class RealTransformerAbstractTest {
         final double[] expected = transform(x, type);
         final double[] actual = transformer.apply(f, a, b, n);
         for (int i = 0; i < n; i++) {
-            final String msg = String.format("%d, %d", n, i);
+            final String msg = "%d, %d".formatted(n, i);
             final double delta = tol * Math.abs(expected[i]);
             Assert.assertEquals(msg, expected[i], actual[i], delta);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
   <inceptionYear>2003</inceptionYear>
 
   <properties>
+  <javaVersion>17</javaVersion>
     <!-- Do not change: "math" is the name of the component even if the
          name of the base package evolves with major release numbers
          (see "commons.osgi.symbolicName", below). -->
@@ -57,8 +58,8 @@
     <commons.jira.id>MATH</commons.jira.id>
     <commons.jira.pid>12310485</commons.jira.pid>
     <commons.encoding>UTF-8</commons.encoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <!-- MathJax configuration. See the maven-javadoc-plugin plugin. -->
     <math.mathjax.url>https://commons.apache.org/js/mathjax/tex-mml-chtml.js</math.mathjax.url>
     <math.commons.numbers.version>1.3</math.commons.numbers.version>


### PR DESCRIPTION
﻿## Summary

This PR upgrades the project from Java 8 to Java 17, applying modern Java language features and updating the build configuration accordingly.

## Changes

- Updated source/target from 8 to 17
- Applied instanceof pattern matching
- Added @Serial annotation to serialVersionUID fields
- Converted String.format to .formatted
- Replaced Paths.get with Path.of
- Converted multiline strings to text blocks

## Statistics

129 files changed, 476 insertions, 270 deletions

## Verification

- BUILD SUCCESS with JDK 17 across all 14 modules
