### PR TITLE
fix int overflow in pos + size bounds check in array vector constructors

### DIFF
--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/ArrayFieldVector.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/ArrayFieldVector.java
@@ -187,8 +187,9 @@ public class ArrayFieldVector<T extends FieldElement<T>> implements FieldVector<
     public ArrayFieldVector(T[] d, int pos, int size)
             throws NullArgumentException, NumberIsTooLargeException {
         NullArgumentException.check(d);
-        if (d.length < pos + size) {
-            throw new NumberIsTooLargeException(pos + size, d.length, true);
+        if (d.length < (long) pos + size) {
+            throw new NumberIsTooLargeException(Long.valueOf((long) pos + size),
+                                                Integer.valueOf(d.length), true);
         }
         field = d[0].getField();
         data = MathArrays.buildArray(field, size);
@@ -209,8 +210,9 @@ public class ArrayFieldVector<T extends FieldElement<T>> implements FieldVector<
     public ArrayFieldVector(Field<T> field, T[] d, int pos, int size)
             throws NullArgumentException, NumberIsTooLargeException {
         NullArgumentException.check(d);
-        if (d.length < pos + size) {
-            throw new NumberIsTooLargeException(pos + size, d.length, true);
+        if (d.length < (long) pos + size) {
+            throw new NumberIsTooLargeException(Long.valueOf((long) pos + size),
+                                                Integer.valueOf(d.length), true);
         }
         this.field = field;
         data = MathArrays.buildArray(field, size);

--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/ArrayRealVector.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/linear/ArrayRealVector.java
@@ -121,8 +121,9 @@ public class ArrayRealVector extends RealVector implements Serializable {
         if (d == null) {
             throw new NullArgumentException();
         }
-        if (d.length < pos + size) {
-            throw new NumberIsTooLargeException(pos + size, d.length, true);
+        if (d.length < (long) pos + size) {
+            throw new NumberIsTooLargeException(Long.valueOf((long) pos + size),
+                                                Integer.valueOf(d.length), true);
         }
         data = new double[size];
         System.arraycopy(d, pos, data, 0, size);
@@ -155,8 +156,9 @@ public class ArrayRealVector extends RealVector implements Serializable {
         if (d == null) {
             throw new NullArgumentException();
         }
-        if (d.length < pos + size) {
-            throw new NumberIsTooLargeException(pos + size, d.length, true);
+        if (d.length < (long) pos + size) {
+            throw new NumberIsTooLargeException(Long.valueOf((long) pos + size),
+                                                Integer.valueOf(d.length), true);
         }
         data = new double[size];
         for (int i = pos; i < pos + size; i++) {

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/ArrayFieldVectorTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/ArrayFieldVectorTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.math4.legacy.core.Field;
 import org.apache.commons.math4.legacy.core.FieldElement;
 import org.apache.commons.math4.legacy.TestUtils;
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
+import org.apache.commons.math4.legacy.exception.NumberIsTooLargeException;
 import org.apache.commons.math4.legacy.exception.NumberIsTooSmallException;
 import org.apache.commons.math4.legacy.exception.OutOfRangeException;
 import org.apache.commons.math4.legacy.core.dfp.Dfp;
@@ -350,6 +351,24 @@ public class ArrayFieldVectorTest {
         ArrayFieldVector<Dfp> v9 = new ArrayFieldVector<>((FieldVector<Dfp>) v1, (FieldVector<Dfp>) v3);
         Assert.assertEquals(10, v9.getDimension());
         Assert.assertEquals(Dfp25.of(1), v9.getEntry(7));
+    }
+
+    @Test
+    public void testConstructorPosSizeOverflow() {
+        // pos + size overflows int and wraps negative; the bounds check must
+        // still reject the range and report the true value in the exception.
+        try {
+            new ArrayFieldVector<>(vec4, Integer.MAX_VALUE, 1);
+            Assert.fail("NumberIsTooLargeException expected");
+        } catch (NumberIsTooLargeException ex) {
+            Assert.assertEquals(1L + Integer.MAX_VALUE, ex.getArgument().longValue());
+        }
+        try {
+            new ArrayFieldVector<>(Dfp25.getField(), vec4, Integer.MAX_VALUE, 1);
+            Assert.fail("NumberIsTooLargeException expected");
+        } catch (NumberIsTooLargeException ex) {
+            Assert.assertEquals(1L + Integer.MAX_VALUE, ex.getArgument().longValue());
+        }
     }
 
     @Test

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/ArrayRealVectorTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/linear/ArrayRealVectorTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.math4.legacy.linear;
 
 import org.apache.commons.math4.legacy.exception.MathIllegalArgumentException;
+import org.apache.commons.math4.legacy.exception.NumberIsTooLargeException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -142,6 +143,25 @@ public class ArrayRealVectorTest extends RealVectorAbstractTest {
         Assert.assertEquals("testData len", 12, v14.getDimension());
         Assert.assertEquals("testData is 9.0 ", 9.0, v14.getEntry(2), 0);
         Assert.assertEquals("testData is 1.0 ", 1.0, v14.getEntry(3), 0);
+    }
+
+    @Test
+    public void testConstructorPosSizeOverflow() {
+        final double[] d = {1d, 2d, 3d};
+        // pos + size overflows int and wraps negative; the bounds check must
+        // still reject the range and report the true value in the exception.
+        try {
+            new ArrayRealVector(d, Integer.MAX_VALUE, 1);
+            Assert.fail("NumberIsTooLargeException expected");
+        } catch (NumberIsTooLargeException ex) {
+            Assert.assertEquals(1L + Integer.MAX_VALUE, ex.getArgument().longValue());
+        }
+        try {
+            new ArrayRealVector(new Double[] {1d, 2d, 3d}, Integer.MAX_VALUE, 1);
+            Assert.fail("NumberIsTooLargeException expected");
+        } catch (NumberIsTooLargeException ex) {
+            Assert.assertEquals(1L + Integer.MAX_VALUE, ex.getArgument().longValue());
+        }
     }
 
     @Test


### PR DESCRIPTION
Spotted while reading the ArrayRealVector/ArrayFieldVector subarray constructors: the `d.length < pos + size` check computes `pos + size` as int, so a large `pos` wraps it negative and the check is skipped. The constructor then throws a raw ArrayIndexOutOfBoundsException instead of the documented NumberIsTooLargeException, and the message reports the wrapped value. Widened the sum to long in all four constructors and added tests that fail without the change.