### PR TITLE
validate direction number degree in SobolSequenceGenerator stream parser

### DIFF
--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/random/SobolSequenceGenerator.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/random/SobolSequenceGenerator.java
@@ -205,6 +205,9 @@ public class SobolSequenceGenerator implements Supplier<double[]> {
                     dim = Integer.parseInt(st.nextToken());
                     if (dim >= 2 && dim <= dimension) { // we have found the right dimension
                         final int s = Integer.parseInt(st.nextToken());
+                        if (s < 1 || s > BITS) {
+                            throw new MathParseException(line, lineNumber);
+                        }
                         final int a = Integer.parseInt(st.nextToken());
                         final int[] m = new int[s + 1];
                         for (int i = 1; i <= s; i++) {

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/SobolSequenceGeneratorTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/SobolSequenceGeneratorTest.java
@@ -95,7 +95,7 @@ public class SobolSequenceGeneratorTest {
     }
 
     @Test
-    public void testConstructorDegreeTooLarge() {
+    public void testConstructorDegreeTooLarge() throws Exception {
         // direction number degree s = 60 exceeds the BITS (52) entries available
         // per dimension; without range validation this indexes past direction[d]
         // and throws ArrayIndexOutOfBoundsException instead of MathParseException.

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/SobolSequenceGeneratorTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/random/SobolSequenceGeneratorTest.java
@@ -18,8 +18,11 @@ package org.apache.commons.math4.legacy.random;
 
 import org.junit.Assert;
 
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
+import org.apache.commons.math4.legacy.exception.MathParseException;
 import org.apache.commons.math4.legacy.exception.OutOfRangeException;
 import org.junit.Before;
 import org.junit.Test;
@@ -87,6 +90,24 @@ public class SobolSequenceGeneratorTest {
             new SobolSequenceGenerator(21202);
             Assert.fail("an exception should have been thrown");
         } catch (OutOfRangeException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void testConstructorDegreeTooLarge() {
+        // direction number degree s = 60 exceeds the BITS (52) entries available
+        // per dimension; without range validation this indexes past direction[d]
+        // and throws ArrayIndexOutOfBoundsException instead of MathParseException.
+        final StringBuilder sb = new StringBuilder("d s a m_i\n2 60 0");
+        for (int i = 0; i < 60; i++) {
+            sb.append(" 1");
+        }
+        final InputStream is = new ByteArrayInputStream(sb.toString().getBytes(StandardCharsets.UTF_8));
+        try {
+            new SobolSequenceGenerator(2, is);
+            Assert.fail("an exception should have been thrown");
+        } catch (MathParseException e) {
             // expected
         }
     }


### PR DESCRIPTION
SobolSequenceGenerator.initFromStream reads a per-dimension degree `s` from the direction-number stream passed to the public `SobolSequenceGenerator(int, InputStream)` constructor, then allocates `new int[s + 1]` and writes `direction[d][1..s]` even though each `direction[d]` holds only `BITS + 1` entries. A line with `s > BITS` throws a raw ArrayIndexOutOfBoundsException and `s < 1` throws NegativeArraySizeException, instead of the MathParseException this parser uses for every other malformed line. Reject out-of-range `s` before the allocation so bad input maps to MathParseException like the surrounding token parsing.