### PR TITLE
fix off-by-one rejecting trailing nan/infinity in parseNumber

### DIFF
--- a/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/util/CompositeFormat.java
+++ b/commons-math-legacy/src/main/java/org/apache/commons/math4/legacy/util/CompositeFormat.java
@@ -117,7 +117,7 @@ public final class CompositeFormat {
         final int n = sb.length();
         final int startIndex = pos.getIndex();
         final int endIndex = startIndex + n;
-        if (endIndex < source.length() &&
+        if (endIndex <= source.length() &&
             source.substring(startIndex, endIndex).compareTo(sb.toString()) == 0) {
             ret = Double.valueOf(value);
             pos.setIndex(endIndex);

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/util/ComplexFormatAbstractTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/util/ComplexFormatAbstractTest.java
@@ -278,6 +278,22 @@ public abstract class ComplexFormatAbstractTest {
     }
 
     @Test
+    public void testParseRealNan() {
+        // a real-only special value runs to the last character of the string
+        Complex expected = Complex.ofCartesian(Double.NaN, 0);
+        Assert.assertEquals(expected, complexFormat.parse("(NaN)"));
+        Assert.assertEquals(expected, complexFormat.parse(complexFormat.format(expected)));
+    }
+
+    @Test
+    public void testParseRealInfinity() {
+        Complex positive = Complex.ofCartesian(Double.POSITIVE_INFINITY, 0);
+        Assert.assertEquals(positive, complexFormat.parse("(Infinity)"));
+        Complex negative = Complex.ofCartesian(Double.NEGATIVE_INFINITY, 0);
+        Assert.assertEquals(negative, complexFormat.parse("(-Infinity)"));
+    }
+
+    @Test
     public void testConstructorSingleFormat() {
         NumberFormat nf = NumberFormat.getInstance();
         ComplexFormat cf = new ComplexFormat(nf);

--- a/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/util/ComplexFormatAbstractTest.java
+++ b/commons-math-legacy/src/test/java/org/apache/commons/math4/legacy/util/ComplexFormatAbstractTest.java
@@ -289,8 +289,21 @@ public abstract class ComplexFormatAbstractTest {
     public void testParseRealInfinity() {
         Complex positive = Complex.ofCartesian(Double.POSITIVE_INFINITY, 0);
         Assert.assertEquals(positive, complexFormat.parse("(Infinity)"));
+        Assert.assertEquals(positive, complexFormat.parse(complexFormat.format(positive)));
         Complex negative = Complex.ofCartesian(Double.NEGATIVE_INFINITY, 0);
         Assert.assertEquals(negative, complexFormat.parse("(-Infinity)"));
+        Assert.assertEquals(negative, complexFormat.parse(complexFormat.format(negative)));
+    }
+
+    @Test
+    public void testParseImaginarySpecialValue() {
+        // the special value sits in the imaginary part, ahead of the imaginary character
+        Complex nan = Complex.ofCartesian(1.23, Double.NaN);
+        Assert.assertEquals(nan, complexFormat.parse(complexFormat.format(nan)));
+        Complex positive = Complex.ofCartesian(1.23, Double.POSITIVE_INFINITY);
+        Assert.assertEquals(positive, complexFormat.parse(complexFormat.format(positive)));
+        Complex negative = Complex.ofCartesian(1.23, Double.NEGATIVE_INFINITY);
+        Assert.assertEquals(negative, complexFormat.parse(complexFormat.format(negative)));
     }
 
     @Test


### PR DESCRIPTION
CompositeFormat.parseNumber checks endIndex < source.length() before matching a special value like (NaN) or (Infinity), so a special-value token that runs to the final character of the input is never recognised. This breaks the format/parse round trip for a real-only NaN or infinity in ComplexFormat, where parse throws MathParseException on the very string format produced. Widening the comparison to endIndex <= source.length() lets a special value ending the input parse, which also covers RealVectorFormat and RealMatrixFormat as they share the same helper.