### PR TITLE
Restrict trigger push branch for GitHub Workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,8 @@ on:
   workflow_dispatch:
   # Don't trigger if other workfiles change
   push:
+    branches:
+      - master
     paths-ignore:
       - '**/workflows/*.yml'
       - '!**/workflows/coverage.yml'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,6 +20,8 @@ on:
   workflow_dispatch:
   # Don't trigger if other workfiles change
   push:
+    branches:
+      - master
     paths-ignore:
       - '**/workflows/*.yml'
       - '!**/workflows/maven.yml'

--- a/.github/workflows/maven_legacy.yml
+++ b/.github/workflows/maven_legacy.yml
@@ -20,6 +20,8 @@ on:
   workflow_dispatch:
   # self trigger
   push:
+    branches:
+      - master
     paths:
       - '**/workflows/maven_legacy.yml'
       - 'commons-math-legacy/**'


### PR DESCRIPTION
Feature branches rarely need their own CI runs: the code is already tested when a pull request is opened against a release branch. If the push trigger has no branch restriction and pull_request is also configured, every push to a branch with an open PR runs the workflow twice: once for the push and once for the PR synchronisation.

Always give the push trigger an explicit list of branches: this stops branches created from a release branch from inheriting its workflow runs.

see https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=430408443#GitHubActionsRecommendedPractices-Restrictthepushtriggertospecificbranches